### PR TITLE
Add option to anonymize IPs before storing to DB

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -77,6 +77,18 @@ form:
             label: PLUGIN_PAGE_STATS.STATS_DB_LABEL
             help: PLUGIN_PAGE_STATS.STATS_DB_HELP
 
+        anonymize_ips:
+            type: toggle
+            label: PLUGIN_PAGE_STATS.ANONYMIZE_IPS_LABEL
+            help: PLUGIN_PAGE_STATS.ANONYMIZE_IPS_HELP
+            highlight: 1
+            default: 0
+            options:
+                1: PLUGIN_ADMIN.ENABLED
+                0: PLUGIN_ADMIN.DISABLED
+            validate:
+                type: bool
+
 
         section_widgets:
             type: section

--- a/languages.yaml
+++ b/languages.yaml
@@ -19,6 +19,8 @@ en:
             TEXT: Style
             HELP: The style used to present data (table or chart)
 
+    ANONYMIZE_IPS_LABEL: Anonymize IP-addresses
+    ANONYMIZE_IPS_HELP: "If enabled IP-addresses will be truncated after 2 Bytes (for IPv4) and 4 Bytes (for IPv6) before storing to database for eased GDPR compliance. NOTICE: This ONLY applies for NEWLY recorded visits, NOT for entries already recorded in the database."
 
     LOG_TIME_ON_PAGE_LABEL: Log time on page
     LOG_TIME_ON_PAGE_HELP: If enabled Front End will trigger a ping event at regular intervals to mark the user as still on the page

--- a/page-stats.php
+++ b/page-stats.php
@@ -212,6 +212,16 @@ class PageStatsPlugin extends Plugin
             $browser = $this->grav['browser'];
             $dbPath = $config['db'];
 
+            if ($config['anonymize_ips']) {
+                if (str_contains($ip, ':')) {
+                    // IPv6 (truncate after second ':', i.e. after 4 bytes)
+                    $ip = substr($ip, 0, strpos($ip, ':', strpos($ip, ':')+1)) . '::0';
+                } else {
+                    // IPv4 (truncate after second '.', i.e. after 2 bytes)
+                    $ip = substr($ip, 0, strpos($ip, '.', strpos($ip, '.')+1)) . '.0.0';
+                }
+            }
+
             $stats = new Stats($dbPath, $this->config());
 
             $sessionId = $stats->collect($ip, $geo, $page, $uri, $user, $now, $browser);

--- a/page-stats.yaml
+++ b/page-stats.yaml
@@ -1,6 +1,7 @@
 enabled: true
 db: user/data/page-data.sqlite
 ignore_errors: true
+anonymize_ips: false
 log_admin: true
 log_bot: true
 page_url_format: 'url'


### PR DESCRIPTION
First of all, thanks for this awesome plugin!

As I'd like to use this in Germany without having to inform my users/obtain consent, I wanted an option to anonymize users, such that it is not possible to identify them. Therefore I added an option to truncate IP addresses before storing them to the database. I'm not sure whether this is actually sufficient, as I'm not a lawyer, but I guess it's a start.

Not sure if this is something you would like to be added to your plugin, but thought I'd just leave it here for you to decide. Feel free to comment/change/decline as you see fit.