### PR TITLE
Display page stats in localtime by default and allow configuring a fixed offset

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -182,6 +182,13 @@ form:
             text: PLUGIN_PAGE_STATS.SECTION_BEHAVIOUR_LABEL
             underline: true
             fields:
+                datetime_offset:
+                    type: text
+                    label: PLUGIN_PAGE_STATS.DATETIME_OFFSET_LABEL
+                    help: PLUGIN_PAGE_STATS.DATETIME_OFFSET_HELP
+                    default: 'localtime'
+                    validate:
+                      pattern: '[+-][[:digit:]]{2,2}:[[:digit:]]{2,2}|localtime'
                 log_admin:
                     type: toggle
                     label: PLUGIN_PAGE_STATS.LOG_ADMIN_LABEL

--- a/classes/Stats.php
+++ b/classes/Stats.php
@@ -333,7 +333,7 @@ class Stats
     public function recentPages(int $limit = 10, ?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
     {
         // $q = 'SELECT route, page_title, count(route) as hits, date FROM data GROUP BY route ORDER BY date DESC';
-        $q = 'SELECT *, date(data.date) as day, time(data.date) as time  FROM data %where ORDER BY date DESC';
+        $q = 'SELECT *, date(datetime(data.date), \'localtime\') as day, time(datetime(data.date), \'localtime\') as time  FROM data %where ORDER BY date DESC';
 
         return $this->query($q, $params, $limit, $dateFrom, $dateTo);
     }
@@ -361,9 +361,9 @@ class Stats
      */
     public function siteSummary(?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
     {
-        $hits = $this->query('SELECT date(date) as date, route, page_title, count(route) as hits FROM data %where GROUP BY date(date)', $params, $dateFrom, $dateTo);
-        $visitors = $this->query('SELECT date(date) as date, route, page_title, ip, count(distinct ip) as hits FROM data %where GROUP BY date(date)',  $params, $dateFrom, $dateTo);
-        $users = $this->query('SELECT date(date) as date, route, page_title, ip, count(distinct user) as hits FROM data %where GROUP BY date(date)',  $params, $dateFrom, $dateTo);
+        $hits = $this->query('SELECT date(datetime(date), \'localtime\') as date, route, page_title, count(route) as hits FROM data %where GROUP BY date(datetime(date), \'localtime\')', $params, $dateFrom, $dateTo);
+        $visitors = $this->query('SELECT date(datetime(date), \'localtime\') as date, route, page_title, ip, count(distinct ip) as hits FROM data %where GROUP BY date(datetime(date), \'localtime\')',  $params, $dateFrom, $dateTo);
+        $users = $this->query('SELECT date(datetime(date), \'localtime\') as date, route, page_title, ip, count(distinct user) as hits FROM data %where GROUP BY date(datetime(date), \'localtime\')',  $params, $dateFrom, $dateTo);
 
         return [
             'hits' => $hits,

--- a/classes/Stats.php
+++ b/classes/Stats.php
@@ -25,6 +25,7 @@ class Stats
     {
         $this->config = $config;
         $this->botRegExp = implode('|', $this->config['bot_regexp']);
+        $this->dt_offset = $this->config['datetime_offset'];
 
         $this->dbPath = new \SplFileInfo($dbPath);
         $migrate = !$this->dbPath->isWritable() || file_exists(__DIR__ . self::FORCE_MIGRATION_FLAG);
@@ -206,6 +207,10 @@ class Stats
             $s->bindValue(':' . $key, $value);
         }
 
+        if (str_contains($q, ':offset')) {
+            $s->bindValue(':offset', $this->dt_offset);
+        }
+
 
         $s->execute();
 
@@ -333,7 +338,8 @@ class Stats
     public function recentPages(int $limit = 10, ?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
     {
         // $q = 'SELECT route, page_title, count(route) as hits, date FROM data GROUP BY route ORDER BY date DESC';
-        $q = 'SELECT *, date(datetime(data.date), \'localtime\') as day, time(datetime(data.date), \'localtime\') as time  FROM data %where ORDER BY date DESC';
+
+        $q = 'SELECT *, date(datetime(data.date), :offset) as day, time(datetime(data.date), :offset) as time  FROM data %where ORDER BY date DESC';
 
         return $this->query($q, $params, $limit, $dateFrom, $dateTo);
     }
@@ -361,9 +367,9 @@ class Stats
      */
     public function siteSummary(?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
     {
-        $hits = $this->query('SELECT date(datetime(date), \'localtime\') as date, route, page_title, count(route) as hits FROM data %where GROUP BY date(datetime(date), \'localtime\')', $params, $dateFrom, $dateTo);
-        $visitors = $this->query('SELECT date(datetime(date), \'localtime\') as date, route, page_title, ip, count(distinct ip) as hits FROM data %where GROUP BY date(datetime(date), \'localtime\')',  $params, $dateFrom, $dateTo);
-        $users = $this->query('SELECT date(datetime(date), \'localtime\') as date, route, page_title, ip, count(distinct user) as hits FROM data %where GROUP BY date(datetime(date), \'localtime\')',  $params, $dateFrom, $dateTo);
+        $hits = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, count(route) as hits FROM data %where GROUP BY date(datetime(date), :offset)', $params, $dateFrom, $dateTo);
+        $visitors = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct ip) as hits FROM data %where GROUP BY date(datetime(date), :offset)',  $params, $dateFrom, $dateTo);
+        $users = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct user) as hits FROM data %where GROUP BY date(datetime(date), :offset)',  $params, $dateFrom, $dateTo);
 
         return [
             'hits' => $hits,

--- a/languages.yaml
+++ b/languages.yaml
@@ -20,6 +20,9 @@ en:
             HELP: The style used to present data (table or chart)
 
 
+    DATETIME_OFFSET_LABEL: Date Time Offset From UTC
+    DATETIME_OFFSET_HELP: Display date/time values adjusted from UTC by specified offset
+
     LOG_TIME_ON_PAGE_LABEL: Log time on page
     LOG_TIME_ON_PAGE_HELP: If enabled Front End will trigger a ping event at regular intervals to mark the user as still on the page
     # STATS_DB_CREATE_LABEL: Recreate Stats database

--- a/page-stats.yaml
+++ b/page-stats.yaml
@@ -8,6 +8,7 @@ page_url_format: 'url'
 
 collector_ping_interval: 15
 log_time_on_page: true
+datetime_offset: 'localtime'
 
 show_top_users_widget: true
 cols_top_users_widget: 'col-12 col-md-3'


### PR DESCRIPTION
# Summary
Timestamps are stored in db as strings (as far as I can tell), and include the date time offset from UTC.

## The Problem
Timestamps were formerly displayed as output of sqlite ``date()`` and ``time()`` functions, which causes the times to be displayed as UTC regardless of server timezone.

## The Solution
Given the following behaviour of sqlite3:
* All sqlite date/time functions (without modifiers) return time as UTC time.
* Sqlite date/time functions accept various modifiers including:
   * +/-HH:MM
   * localtime
   * utc

From https://www.sqlite.org/lang_datefunc.html:
* The ``localtime`` modifier converts a UTC time to the text repr of the same moment in local time.
* The ``utc`` modifier converts a local time to the text repr of the same moment in UTC.
* The ``+HH:MM`` or ``-HH:MM`` modifier adjusts the time by the offset specified.

### PR Scope
This PR supports the sqlite3 ``+/-HH:MM`` and ``localtime`` modifiers.

1. The default is ``localtime`` - which lets sqlite adjust the time by the the system timezone (ie, will correctly reflect daylight savings time if applicable).
2. The user may also set an explicit offset from UTC - useful if the server is in a different time zone to the user.

_Default value rationale:_
It is a assumed that typically, the admin user, and site visitors, and server location are (mostly) all in the same timezone.
* The exception to this would be if the server has many intl users.

_Use case for fixed offset from UTC_:
If the user wants times displayed as UTC, then offset +00:00 my be set.
* Note that using the ``utc`` modifier would not be correct as that would treat the UTC time output by the ``datetime()`` function as local time then adjust by the system offset.

### Implementation
When displaying timestamps, first call ``datetime(date)`` to get the time in UTC.
* As the stored date time strings include a fixed offset, this always produces the same moment in time as UTC text repr

Next, call ``date`` or ``time`` with the user configured modifier.
* If offset supplied, the time is adjusted by the offset
* If localtime supplied, the time is adjusted by the current system offset

Any calls to ``date`` or ``time`` in the GROUP BY clause are similarly adjusted so that bucket counts accurately reflect the displayed values.

This resolves the feature request, by allowing the user to set a "home" timezone (well, fixed offset rather than a zone due to sqlite limitations).

Further, the user may set to localtime, which is the true server time zone which will automatically adjust for daylight saving time if applicable.

# Further improvements

Q. What if true timezone support is required - not just fixed UTC offset?
A. Due to limitations in sqlite3 builtin date/time methods, we can not adjust timestamps by arbitrary timezone, only by fixed UTC offset or by the system timezone. However, if we were to pass the timestamps as UTC to the front end without calling ``date`` or ``time`` functions, then we could split the timestamp into date only and time only parts in JavaScript and apply arbitrary timezone adjustments and not just fixed offset.

