### PR TITLE
feat: Grav 2.0 / Admin2 compatibility (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v2.8.0
+## Unreleased
+
+1. [New Features](#new)
+    * feat: Grav 2.0 / Admin2 compatibility (#53) - adds a REST API controller (`classes/Api/PageStatsApiController.php`) exposing the existing `Stats` data layer, and an Admin2 sidebar entry + single-page dashboard (`admin-next/pages/page-stats.js`) with page-view/visitor/user totals, top pages/countries/browsers/platforms/users, recently viewed pages, and page/user lookup. Consolidates the nine separate classic-admin pages into one dashboard, since Admin2 component pages are a single route. Requires a `compatibility` declaration in `blueprints.yaml`, which is also what the Grav 2.0 migration wizard checks - its absence is why older versions were auto-flagged as incompatible. Classic Admin (Grav < 2.0) keeps working unchanged via the existing `onAdminDashboard`/`onAdminPage` hooks.
+1. [Bug Fixes](#bugfix)
+    * bugfix: `getUserIP()` returned `null` in request contexts without a real client IP (e.g. `bin/grav page-system-validator`, which still fires `onPageInitialized`), and `isEnabledForIp(string $ip)` declared a non-nullable parameter - causing an uncaught `TypeError` and a fatal error. `getUserIP()` now returns `?string` and `isEnabledForIp()` accepts `?string`, treating "no IP" as "nothing to log" instead of crashing.
+    * bugfix: `Stats::query()` mishandled date-range filtering whenever both `$dateFrom` and `$dateTo` were passed - the `date_from`/`date_to` values were both used to build the `BETWEEN` clause *and* re-processed by the generic equality-filter loop, producing an invalid `date_from = :date_from` condition (`data` has a `date` column, not `date_from`) and a `SQLSTATE[HY000]: no such column: date_from` error. The `BETWEEN` clause itself also had a placeholder typo (`:dateTo` instead of `:date_to`), and `DateTimeImmutable` objects were bound directly instead of as formatted strings. This is likely why date-range filtering across the plugin has been effectively dead code for years - it seems to have never been exercised with both bounds set at once.
+    * bugfix: `Stats::siteSummary()` called `query()` with the wrong argument order (missing the `$limit` argument), so `$dateFrom` landed in the `?int $limit` slot - a `DateTimeImmutable` object where an `int` was expected - and would fatal with a `TypeError` whenever a date range was actually supplied.
+    * bugfix: `Stats::pagesSummary()`'s SQL was missing `%where` entirely, so bindings for the date range (or query params) had nothing to attach to and SQLite rejected them with `SQLSTATE[HY000]: column index out of range`. Added the missing `%where` so date-range filtering on the "top pages" list actually works.
+1. [Improvements](#improvements)
+    * improvement: `Stats::totalUniqueVisitors()` / `Stats::totalUniqueUsers()` helpers for the new Admin2 overview KPIs
+    * improvement: `Stats::query()` now only binds a parameter if its placeholder is actually present in the final SQL string, as a defensive safety net against further query-builder/SQL mismatches like the `pagesSummary()` one above
+    * improvement: the SQLite connection now sets `PRAGMA busy_timeout` (5s) and `PRAGMA journal_mode = WAL`. Without these, concurrent requests writing to the stats database serialize on a single file lock (default `busy_timeout` is 0) and every commit fsyncs the whole rollback journal; under real traffic this can make individual requests noticeably slower and, in the worst case, pile up PHP-FPM workers waiting on the same lock until the pool is exhausted - taking down unrelated requests too, not just page-stats.
+
 # v2.5.3
 ## 09/01/2023
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The **Page Stats** Plugin is an extension for [Grav CMS](http://github.com/getgrav/grav).
 
-Enhaced statistics for grav
+Enhaced statistics for grav 2
 
 This plugin will create a new entry in the admin plugin sidebar to display enhaced page stats about your site!
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The **Page Stats** Plugin is an extension for [Grav CMS](http://github.com/getgrav/grav).
 
-Enhaced statistics for grav 2
+Enhaced statistics for grav
 
 This plugin will create a new entry in the admin plugin sidebar to display enhaced page stats about your site!
 

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -1,0 +1,345 @@
+const TAG = window.__GRAV_PAGE_TAG || 'grav-page-stats--page-stats';
+
+/**
+ * Admin2 component-mode page for the Page Stats plugin.
+ *
+ * Talks to the REST endpoints registered by
+ * classes/Api/PageStatsApiController.php (see page-stats.php ->
+ * onApiRegisterRoutes) to render an overview dashboard, plus small
+ * lookup tools for a single page or a single user.
+ *
+ * This intentionally consolidates the nine separate classic-admin pages
+ * (stats / page-details / user-details / all-pages / top-countries /
+ * top-browsers / top-platforms / top-users / recently-viewed-pages) into
+ * one dashboard with inline lookups, since Admin2 component pages are a
+ * single route rather than a set of admin-theme templates.
+ */
+class PageStatsPage extends HTMLElement {
+    #range = '30';
+    #overview = null;
+    #loading = false;
+
+    connectedCallback() {
+        this.attachShadow({ mode: 'open' });
+        this._render();
+        this._load();
+    }
+
+    _apiUrl(path) {
+        const base = window.__GRAV_API_SERVER_URL || '';
+        const prefix = window.__GRAV_API_PREFIX || '/api/v1';
+        return `${base}${prefix}${path}`;
+    }
+
+    _apiHeaders() {
+        const headers = {};
+        const token = window.__GRAV_API_TOKEN;
+        if (token) headers['X-API-Token'] = token;
+        return headers;
+    }
+
+    async _apiGet(path, params = {}) {
+        const query = new URLSearchParams(params).toString();
+        const url = this._apiUrl(path) + (query ? `?${query}` : '');
+        const resp = await fetch(url, { headers: this._apiHeaders() });
+        if (!resp.ok) {
+            const body = await resp.json().catch(() => ({}));
+            throw new Error(body.detail || body.title || `Request failed (${resp.status})`);
+        }
+        const json = await resp.json();
+        return json.data !== undefined ? json.data : json;
+    }
+
+    _dateRangeParams() {
+        if (this.#range === 'all') return {};
+        const days = parseInt(this.#range, 10);
+        const to = new Date();
+        const from = new Date();
+        from.setDate(from.getDate() - days);
+        return {
+            date_from: from.toISOString(),
+            date_to: to.toISOString(),
+        };
+    }
+
+    async _load() {
+        this.#loading = true;
+        this._renderBody();
+        try {
+            this.#overview = await this._apiGet('/page-stats/overview', this._dateRangeParams());
+        } catch (err) {
+            this.#overview = null;
+            this._error = err.message;
+            window.__GRAV_TOAST?.error(err.message || 'Could not load page stats');
+        } finally {
+            this.#loading = false;
+            this._renderBody();
+        }
+    }
+
+    _render() {
+        this.shadowRoot.innerHTML = `
+            <style>${this._styles()}</style>
+            <div class="wrap">
+                <div class="toolbar">
+                    <div class="range">
+                        <button data-range="7">7d</button>
+                        <button data-range="30">30d</button>
+                        <button data-range="90">90d</button>
+                        <button data-range="all">All time</button>
+                    </div>
+                    <button class="refresh" title="Refresh">&#8635; Refresh</button>
+                </div>
+                <div class="body"></div>
+
+                <div class="lookup">
+                    <div class="lookup-box">
+                        <h3>Page lookup</h3>
+                        <div class="lookup-row">
+                            <input type="text" class="page-route" placeholder="/blog/some-article" />
+                            <button class="page-search">Search</button>
+                        </div>
+                        <div class="page-result"></div>
+                    </div>
+                    <div class="lookup-box">
+                        <h3>User lookup</h3>
+                        <div class="lookup-row">
+                            <input type="text" class="user-name" placeholder="username" />
+                            <button class="user-search">Search</button>
+                        </div>
+                        <div class="user-result"></div>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        const root = this.shadowRoot;
+        root.querySelectorAll('.range button').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                this.#range = btn.dataset.range;
+                this._highlightRange();
+                this._load();
+            });
+        });
+        root.querySelector('.refresh').addEventListener('click', () => this._load());
+        root.querySelector('.page-search').addEventListener('click', () => this._searchPage());
+        root.querySelector('.user-search').addEventListener('click', () => this._searchUser());
+        root.querySelector('.page-route').addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') this._searchPage();
+        });
+        root.querySelector('.user-name').addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') this._searchUser();
+        });
+
+        this._highlightRange();
+    }
+
+    _highlightRange() {
+        this.shadowRoot.querySelectorAll('.range button').forEach((btn) => {
+            btn.classList.toggle('active', btn.dataset.range === this.#range);
+        });
+    }
+
+    _renderBody() {
+        const body = this.shadowRoot.querySelector('.body');
+        if (!body) return;
+
+        if (this.#loading) {
+            body.innerHTML = `<div class="state">Loading…</div>`;
+            return;
+        }
+
+        if (!this.#overview) {
+            body.innerHTML = `<div class="state error">${this._error || 'No data available.'}</div>`;
+            return;
+        }
+
+        const o = this.#overview;
+
+        body.innerHTML = `
+            <div class="kpis">
+                ${this._kpi('Page views', o.total_page_views)}
+                ${this._kpi('Unique visitors', o.total_unique_visitors)}
+                ${this._kpi('Unique users', o.total_unique_users)}
+                ${this._kpi('Database size', `${o.db?.mb ?? 0} MB`)}
+            </div>
+
+            <div class="grid">
+                <div class="card wide">
+                    <h3>Top pages</h3>
+                    ${this._table(
+                        ['Page', 'Hits', 'Visitors'],
+                        (o.top_pages || []).map((p) => [
+                            `<span title="${this._esc(p.route)}">${this._esc(p.page_title || p.route)}</span>`,
+                            p.hits,
+                            p.visitors,
+                        ])
+                    )}
+                </div>
+
+                <div class="card">
+                    <h3>Top countries</h3>
+                    ${this._bars(o.top_countries, 'country')}
+                </div>
+
+                <div class="card">
+                    <h3>Top browsers</h3>
+                    ${this._bars(o.top_browsers, 'browser')}
+                </div>
+
+                <div class="card">
+                    <h3>Top platforms</h3>
+                    ${this._bars(o.top_platforms, 'platform')}
+                </div>
+
+                <div class="card">
+                    <h3>Top users</h3>
+                    ${this._table(
+                        ['User', 'Hits'],
+                        (o.top_users || []).map((u) => [this._esc(u.user || '(anonymous)'), u.hits])
+                    )}
+                </div>
+
+                <div class="card wide">
+                    <h3>Recently viewed pages</h3>
+                    ${this._table(
+                        ['Route', 'User', 'Date'],
+                        (o.recent_pages || []).map((r) => [
+                            this._esc(r.route),
+                            this._esc(r.user || '(anonymous)'),
+                            `${this._esc(r.day || '')} ${this._esc(r.time || '')}`,
+                        ])
+                    )}
+                </div>
+            </div>
+        `;
+    }
+
+    _kpi(label, value) {
+        return `<div class="kpi"><div class="kpi-value">${this._esc(String(value ?? '0'))}</div><div class="kpi-label">${this._esc(label)}</div></div>`;
+    }
+
+    _bars(items, key) {
+        if (!items || !items.length) return `<div class="state">No data.</div>`;
+        const max = Math.max(...items.map((i) => Number(i.hits) || 0), 1);
+        return `<div class="bars">${items
+            .map((i) => {
+                const pct = Math.max(4, Math.round(((Number(i.hits) || 0) / max) * 100));
+                return `
+                    <div class="bar-row">
+                        <span class="bar-label">${this._esc(String(i[key] || 'unknown'))}</span>
+                        <div class="bar-track"><div class="bar-fill" style="width:${pct}%"></div></div>
+                        <span class="bar-value">${this._esc(String(i.hits))}${i.share !== undefined ? ` (${i.share}%)` : ''}</span>
+                    </div>`;
+            })
+            .join('')}</div>`;
+    }
+
+    _table(headers, rows) {
+        if (!rows.length) return `<div class="state">No data.</div>`;
+        return `
+            <table>
+                <thead><tr>${headers.map((h) => `<th>${this._esc(h)}</th>`).join('')}</tr></thead>
+                <tbody>${rows.map((r) => `<tr>${r.map((c) => `<td>${c}</td>`).join('')}</tr>`).join('')}</tbody>
+            </table>`;
+    }
+
+    async _searchPage() {
+        const route = this.shadowRoot.querySelector('.page-route').value.trim();
+        const resultEl = this.shadowRoot.querySelector('.page-result');
+        if (!route) return;
+        resultEl.innerHTML = `<div class="state">Searching…</div>`;
+        try {
+            const data = await this._apiGet('/page-stats/pages/detail', { route, limit: 50 });
+            resultEl.innerHTML = `
+                <p>${data.hits} hits, ${data.visitors} unique visitors</p>
+                ${this._table(
+                    ['User', 'Date', 'Browser'],
+                    (data.views || []).map((v) => [
+                        this._esc(v.user || '(anonymous)'),
+                        `${this._esc(v.day || '')} ${this._esc(v.time || '')}`,
+                        this._esc(v.browser || ''),
+                    ])
+                )}`;
+        } catch (err) {
+            resultEl.innerHTML = `<div class="state error">${this._esc(err.message)}</div>`;
+        }
+    }
+
+    async _searchUser() {
+        const user = this.shadowRoot.querySelector('.user-name').value.trim();
+        const resultEl = this.shadowRoot.querySelector('.user-result');
+        if (!user) return;
+        resultEl.innerHTML = `<div class="state">Searching…</div>`;
+        try {
+            const data = await this._apiGet('/page-stats/users/detail', { user, limit: 50 });
+            resultEl.innerHTML = `
+                <p>${data.hits} hits</p>
+                ${this._table(
+                    ['Route', 'Date'],
+                    (data.views || []).map((v) => [this._esc(v.route || ''), `${this._esc(v.day || '')} ${this._esc(v.time || '')}`])
+                )}`;
+        } catch (err) {
+            resultEl.innerHTML = `<div class="state error">${this._esc(err.message)}</div>`;
+        }
+    }
+
+    _esc(str) {
+        const div = document.createElement('div');
+        div.textContent = str ?? '';
+        return div.innerHTML;
+    }
+
+    _styles() {
+        return `
+            :host { display: block; color: var(--foreground); font-family: inherit; }
+            .wrap { display: flex; flex-direction: column; gap: 16px; }
+            .toolbar { display: flex; justify-content: space-between; align-items: center; }
+            .range { display: flex; gap: 4px; }
+            .range button, .refresh, .lookup-row button {
+                background: var(--background);
+                color: var(--foreground);
+                border: 1px solid var(--border);
+                border-radius: 6px;
+                padding: 6px 12px;
+                cursor: pointer;
+                font-size: 13px;
+            }
+            .range button.active { background: var(--primary); color: var(--primary-foreground, #fff); border-color: var(--primary); }
+            .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+            .kpi { border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
+            .kpi-value { font-size: 22px; font-weight: 700; }
+            .kpi-label { font-size: 12px; color: var(--muted-foreground); margin-top: 4px; }
+            .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 12px; }
+            .card { border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+            .card.wide { grid-column: 1 / -1; }
+            .card h3 { margin: 0 0 10px; font-size: 14px; }
+            table { width: 100%; border-collapse: collapse; font-size: 13px; }
+            th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--border); }
+            th { color: var(--muted-foreground); font-weight: 600; }
+            .bars { display: flex; flex-direction: column; gap: 8px; }
+            .bar-row { display: grid; grid-template-columns: 90px 1fr 70px; align-items: center; gap: 8px; font-size: 13px; }
+            .bar-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+            .bar-track { background: var(--border); border-radius: 4px; height: 8px; overflow: hidden; }
+            .bar-fill { background: var(--primary); height: 100%; }
+            .bar-value { text-align: right; color: var(--muted-foreground); }
+            .state { color: var(--muted-foreground); font-size: 13px; padding: 8px 0; }
+            .state.error { color: var(--destructive, #dc2626); }
+            .lookup { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 12px; }
+            .lookup-box { border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+            .lookup-box h3 { margin: 0 0 10px; font-size: 14px; }
+            .lookup-row { display: flex; gap: 8px; margin-bottom: 10px; }
+            .lookup-row input {
+                flex: 1;
+                background: var(--background);
+                color: var(--foreground);
+                border: 1px solid var(--border);
+                border-radius: 6px;
+                padding: 6px 8px;
+                font-size: 13px;
+            }
+        `;
+    }
+}
+
+customElements.define(TAG, PageStatsPage);

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Page Stats
 slug: page-stats
 type: plugin
-version: 2.7.1
+version: 2.8.0
 description: Enhaced Analytics for grav
 icon: plug
 author:
@@ -15,6 +15,16 @@ license: MIT
 
 dependencies:
     - { name: grav, version: ">=1.6.0" }
+
+# Declares compatibility with the Grav 2.0 API plugin / Admin2.
+# See classes/Api/PageStatsApiController.php and admin-next/pages/page-stats.js.
+# Classic Admin (Grav < 2.0) continues to work unchanged via the existing
+# onAdminDashboard/onAdminPage hooks in page-stats.php.
+compatibility:
+    grav:
+        - 2.0
+    api:
+        - 1.0
 
 x-widget-enabled: &widget-enabled
     type: toggle

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -22,7 +22,8 @@ dependencies:
 # onAdminDashboard/onAdminPage hooks in page-stats.php.
 compatibility:
     grav:
-        - 2.0
+        - '1.7'
+        - '2.0'
     api:
         - 1.0
 

--- a/classes/Api/PageStatsApiController.php
+++ b/classes/Api/PageStatsApiController.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Grav\Plugin\PageStats\Api;
+
+use DateTimeImmutable;
+use Grav\Common\Grav;
+use Grav\Plugin\Api\Controllers\AbstractApiController;
+use Grav\Plugin\Api\Exceptions\ValidationException;
+use Grav\Plugin\Api\Response\ApiResponse;
+use Grav\Plugin\PageStats\Stats;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Exposes the Page Stats data layer (classes/Stats.php) as a set of read-only
+ * REST endpoints consumed by the Admin2 (grav-plugin-admin2) dashboard page
+ * shipped in admin-next/pages/page-stats.js.
+ *
+ * The stored/collected data itself is untouched - this class is purely a
+ * presentation-layer bridge between the existing Stats class and the new
+ * Grav 2.0 API/Admin2 architecture, which replaced the classic Admin's
+ * onAdminDashboard / onAdminPage / plugins_hooked_nav mechanism used by
+ * versions of this plugin prior to 2.8.
+ */
+class PageStatsApiController extends AbstractApiController
+{
+    private const READ_PERMISSION = 'api.system.read';
+
+    /**
+     * GET /page-stats/overview
+     *
+     * Compact summary used to populate the dashboard's KPI cards and
+     * "top N" widgets in a single request.
+     */
+    public function overview(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $stats = $this->getStats();
+
+        $totalViews = $stats->totalPageViews($dateFrom, $dateTo);
+        $totalVisitors = $stats->totalUniqueVisitors($dateFrom, $dateTo);
+        $totalUsers = $stats->totalUniqueUsers($dateFrom, $dateTo);
+
+        return ApiResponse::create([
+            'db' => $stats->dbStats(),
+            'total_page_views' => (int) ($totalViews[0]['hits'] ?? 0),
+            'total_unique_visitors' => (int) ($totalVisitors[0]['visitors'] ?? 0),
+            'total_unique_users' => (int) ($totalUsers[0]['users'] ?? 0),
+            'top_pages' => $stats->pagesSummary(5, $dateFrom, $dateTo),
+            'top_countries' => $stats->topCountries(5, $dateFrom, $dateTo),
+            'top_browsers' => $stats->topBrowsers(5, $dateFrom, $dateTo),
+            'top_platforms' => $stats->topPlatforms(5, $dateFrom, $dateTo),
+            'top_users' => $stats->topUsers(5, $dateFrom, $dateTo),
+            'recent_pages' => $stats->recentPages(10, $dateFrom, $dateTo),
+        ]);
+    }
+
+    /**
+     * GET /page-stats/pages
+     */
+    public function pages(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $limit = $this->getLimit($request, 50);
+
+        return ApiResponse::create([
+            'pages' => $this->getStats()->pagesSummary($limit, $dateFrom, $dateTo),
+        ]);
+    }
+
+    /**
+     * GET /page-stats/pages/detail?route=/some/route
+     */
+    public function pageDetail(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        $route = $this->getQueryParam($request, 'route');
+        if (!$route) {
+            throw new ValidationException('A "route" query parameter is required.', [
+                ['field' => 'route', 'message' => 'This field is required.'],
+            ]);
+        }
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $limit = $this->getLimit($request, 100);
+
+        $views = $this->getStats()->recentPages($limit, $dateFrom, $dateTo, ['route' => $route]);
+
+        return ApiResponse::create([
+            'route' => $route,
+            'hits' => count($views),
+            'visitors' => count(array_unique(array_column($views, 'ip'))),
+            'views' => $views,
+        ]);
+    }
+
+    /**
+     * GET /page-stats/countries
+     */
+    public function countries(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $limit = $this->getLimit($request, 50);
+
+        return ApiResponse::create([
+            'countries' => $this->getStats()->topCountries($limit, $dateFrom, $dateTo),
+        ]);
+    }
+
+    /**
+     * GET /page-stats/browsers
+     */
+    public function browsers(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $limit = $this->getLimit($request, 50);
+
+        return ApiResponse::create([
+            'browsers' => $this->getStats()->topBrowsers($limit, $dateFrom, $dateTo),
+        ]);
+    }
+
+    /**
+     * GET /page-stats/platforms
+     */
+    public function platforms(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $limit = $this->getLimit($request, 50);
+
+        return ApiResponse::create([
+            'platforms' => $this->getStats()->topPlatforms($limit, $dateFrom, $dateTo),
+        ]);
+    }
+
+    /**
+     * GET /page-stats/users
+     */
+    public function users(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $limit = $this->getLimit($request, 50);
+
+        return ApiResponse::create([
+            'users' => $this->getStats()->topUsers($limit, $dateFrom, $dateTo),
+        ]);
+    }
+
+    /**
+     * GET /page-stats/users/detail?user=someuser
+     */
+    public function userDetail(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        $user = $this->getQueryParam($request, 'user');
+        if (!$user) {
+            throw new ValidationException('A "user" query parameter is required.', [
+                ['field' => 'user', 'message' => 'This field is required.'],
+            ]);
+        }
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $limit = $this->getLimit($request, 100);
+
+        $views = $this->getStats()->recentPages($limit, $dateFrom, $dateTo, ['user' => $user]);
+
+        return ApiResponse::create([
+            'user' => $user,
+            'hits' => count($views),
+            'views' => $views,
+        ]);
+    }
+
+    /**
+     * GET /page-stats/recent
+     */
+    public function recent(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $limit = $this->getLimit($request, 50);
+
+        return ApiResponse::create([
+            'by_day' => $this->getStats()->recentPagesByDay($limit, $dateFrom, $dateTo),
+        ]);
+    }
+
+    /**
+     * GET /page-stats/summary
+     *
+     * Time series data (hits/visitors/users per day) used to draw the trend
+     * chart on the dashboard.
+     */
+    public function summary(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, self::READ_PERMISSION);
+
+        [$dateFrom, $dateTo] = $this->getDateRange($request);
+
+        return ApiResponse::create($this->getStats()->siteSummary($dateFrom, $dateTo));
+    }
+
+    private function getStats(): Stats
+    {
+        $grav = Grav::instance();
+        $config = (array) $grav['config']->get('plugins.page-stats');
+
+        return new Stats($config['db'], $config);
+    }
+
+    private function getLimit(ServerRequestInterface $request, int $default): int
+    {
+        $limit = $this->getQueryParam($request, 'limit');
+
+        return $limit !== null && (int) $limit > 0 ? (int) $limit : $default;
+    }
+
+    /**
+     * @return array{0: ?DateTimeImmutable, 1: ?DateTimeImmutable}
+     */
+    private function getDateRange(ServerRequestInterface $request): array
+    {
+        $from = $this->getQueryParam($request, 'date_from');
+        $to = $this->getQueryParam($request, 'date_to');
+
+        try {
+            $dateFrom = $from ? new DateTimeImmutable($from) : null;
+            $dateTo = $to ? new DateTimeImmutable($to) : null;
+        } catch (\Throwable $e) {
+            $dateFrom = null;
+            $dateTo = null;
+        }
+
+        return [$dateFrom, $dateTo];
+    }
+
+    private function getQueryParam(ServerRequestInterface $request, string $name): ?string
+    {
+        $params = $request->getQueryParams();
+
+        return isset($params[$name]) && $params[$name] !== '' ? (string) $params[$name] : null;
+    }
+}

--- a/classes/Stats.php
+++ b/classes/Stats.php
@@ -291,6 +291,26 @@ class Stats
     }
 
     /**
+     * returns the total number of unique visitors (distinct IPs)
+     */
+    public function totalUniqueVisitors(?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
+    {
+        $q = 'select count(distinct ip) as visitors from data %where';
+
+        return $this->query($q, $params, null, $dateFrom, $dateTo);
+    }
+
+    /**
+     * returns the total number of unique logged in users
+     */
+    public function totalUniqueUsers(?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
+    {
+        $q = "select count(distinct user) as users from data %where";
+
+        return $this->query($q, $params, null, $dateFrom, $dateTo);
+    }
+
+    /**
      * returns the browsers with the most pageviews
      */
     public function topBrowsers(int $limit = 10, ?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])

--- a/classes/Stats.php
+++ b/classes/Stats.php
@@ -224,7 +224,15 @@ class Stats
         $s = $this->db->prepare($q);
 
         foreach ($bindings as $key => $value) {
-            $s->bindValue(':' . $key, $value);
+            // Defensive: only bind values whose placeholder actually made it
+            // into the final SQL. A couple of query builder methods in this
+            // class accept $dateFrom/$dateTo (or other $params) but forget
+            // to include '%where' in their SQL, which meant these bindings
+            // had nothing to attach to and SQLite rejected them with
+            // "column index out of range".
+            if (str_contains($q, ':' . $key)) {
+                $s->bindValue(':' . $key, $value);
+            }
         }
 
         if (str_contains($q, ':offset')) {
@@ -243,7 +251,7 @@ class Stats
      */
     public function pagesSummary(int $limit = 10, ?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null)
     {
-        $q = 'SELECT route, page_title, count(route) as hits, count(distinct ip) as visitors, count(distinct user) as users FROM data GROUP BY page_title ORDER BY hits DESC';
+        $q = 'SELECT route, page_title, count(route) as hits, count(distinct ip) as visitors, count(distinct user) as users FROM data %where GROUP BY page_title ORDER BY hits DESC';
 
         return $this->query($q, [], $limit, $dateFrom, $dateTo);
     }

--- a/classes/Stats.php
+++ b/classes/Stats.php
@@ -192,14 +192,22 @@ class Stats
     private function query(string $q, array $params = [], ?int $limit = null, ?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null)
     {
         $where = [];
-        if ($dateFrom && $dateTo) {
-            $where[] = ' date BETWEEN :date_from AND :dateTo';
-            $params['date_from'] = $dateFrom;
-            $params['date_to'] = $dateTo;
-        }
+        $bindings = [];
 
+        // Equality filters passed in by the caller (e.g. ['route' => $route])
         foreach ($params as $key => $value) {
             $where[] = "$key = :$key";
+            $bindings[$key] = $value;
+        }
+
+        // Date range, handled separately so it never gets run back through
+        // the equality-filter loop above (that previously generated a bogus
+        // "date_from = :date_from" clause - there is no such column, only
+        // "date" - and used a mismatched :dateTo/:date_to placeholder).
+        if ($dateFrom && $dateTo) {
+            $where[] = ' date BETWEEN :date_from AND :date_to';
+            $bindings['date_from'] = $dateFrom->format('c');
+            $bindings['date_to'] = $dateTo->format('c');
         }
 
         if (count($where)) {
@@ -210,12 +218,12 @@ class Stats
 
         if ($limit && (int) $limit > 0) {
             $q .= ' LIMIT :limit';
-            $params['limit'] = $limit;
+            $bindings['limit'] = $limit;
         }
 
         $s = $this->db->prepare($q);
 
-        foreach ($params as $key => $value) {
+        foreach ($bindings as $key => $value) {
             $s->bindValue(':' . $key, $value);
         }
 
@@ -399,9 +407,9 @@ class Stats
      */
     public function siteSummary(?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
     {
-        $hits = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, count(route) as hits FROM data %where GROUP BY date(datetime(date), :offset)', $params, $dateFrom, $dateTo);
-        $visitors = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct ip) as hits FROM data %where GROUP BY date(datetime(date), :offset)',  $params, $dateFrom, $dateTo);
-        $users = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct user) as hits FROM data %where GROUP BY date(datetime(date), :offset)',  $params, $dateFrom, $dateTo);
+        $hits = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, count(route) as hits FROM data %where GROUP BY date(datetime(date), :offset)', $params, null, $dateFrom, $dateTo);
+        $visitors = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct ip) as hits FROM data %where GROUP BY date(datetime(date), :offset)',  $params, null, $dateFrom, $dateTo);
+        $users = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct user) as hits FROM data %where GROUP BY date(datetime(date), :offset)',  $params, null, $dateFrom, $dateTo);
 
         return [
             'hits' => $hits,

--- a/classes/Stats.php
+++ b/classes/Stats.php
@@ -36,6 +36,18 @@ class Stats
             [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
         );
 
+        // Without these, concurrent requests writing to the same SQLite file
+        // fail fast with "database is locked" (default busy_timeout is 0)
+        // and every commit fsyncs the whole rollback journal by default.
+        // Under real traffic (many simultaneous page views) that can pile up
+        // PHP-FPM workers waiting on the same lock and, in the worst case,
+        // exhaust the whole pool - taking down unrelated requests too.
+        // WAL allows one writer + many concurrent readers instead of
+        // serializing everything on a single file lock.
+        $this->db->exec('PRAGMA busy_timeout = 5000');
+        $this->db->exec('PRAGMA journal_mode = WAL');
+        $this->db->exec('PRAGMA synchronous = NORMAL');
+
 
         if ($migrate) {
             $this->migrate();

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,5 @@
     "require-dev": {
         "marcocesarato/php-conventional-changelog": "^1.15"
     },
-    "version": "2.7.1"
+    "version": "2.8.0"
 }

--- a/page-stats.php
+++ b/page-stats.php
@@ -85,7 +85,6 @@ class PageStatsPlugin extends Plugin
      */
     public function onPluginsInitialized(): void
     {
-        $this->grav['log']->info('page-stats DIAGNOSTIC: onPluginsInitialized fired, isAdmin=' . ($this->isAdmin() ? '1' : '0'));
 
         // Don't proceed if we are in the admin plugin
         if ($this->isAdmin()) {
@@ -471,8 +470,6 @@ class PageStatsPlugin extends Plugin
      */
     public function onApiRegisterRoutes(Event $event): void
     {
-        $this->grav['log']->info('page-stats DIAGNOSTIC: onApiRegisterRoutes fired');
-
         $routes = $event['routes'];
         $controller = PageStatsApiController::class;
 
@@ -495,8 +492,6 @@ class PageStatsPlugin extends Plugin
      */
     public function onApiSidebarItems(Event $event): void
     {
-        $this->grav['log']->info('page-stats DIAGNOSTIC: onApiSidebarItems fired');
-
         $items = $event['items'] ?? [];
         $items[] = [
             'id' => self::ADMIN2_PAGE_ID,
@@ -516,8 +511,6 @@ class PageStatsPlugin extends Plugin
      */
     public function onApiPluginPageInfo(Event $event): void
     {
-        $this->grav['log']->info('page-stats DIAGNOSTIC: onApiPluginPageInfo fired, plugin=' . ($event['plugin'] ?? 'NULL'));
-
         if ($event['plugin'] !== 'page-stats') {
             return;
         }

--- a/page-stats.php
+++ b/page-stats.php
@@ -10,6 +10,7 @@ use RocketTheme\Toolbox\Event\Event;;
 
 use Grav\Plugin\PageStats\Geolocation\Geolocation;
 use Grav\Plugin\PageStats\Stats;
+use Grav\Plugin\PageStats\Api\PageStatsApiController;
 use RocketTheme\Toolbox\Event\EventSubscriberInterface;
 use IP2Location\Database;
 
@@ -33,6 +34,12 @@ class PageStatsPlugin extends Plugin
     const PATH_EVENTS_COLLECTION = '/event-collection';
     const PATH_ADMIN_RECENTLY_VIEWED_PAGES = '/recently-viewed-pages';
 
+    // Admin2 sidebar id / route / API prefix (see onApiSidebarItems,
+    // onApiPluginPageInfo, onApiRegisterRoutes)
+    const ADMIN2_PAGE_ID = 'page-stats';
+    const ADMIN2_ROUTE = '/plugin/page-stats';
+    const API_PREFIX = '/page-stats';
+
     /**
      * @return array
      *
@@ -51,7 +58,15 @@ class PageStatsPlugin extends Plugin
                 // ['autoload', 100000],
                 ['onPluginsInitialized', 0]
             ],
-            'onAdminTwigTemplatePaths' => ['onAdminTwigTemplatePaths', 0]
+            // Classic Admin (Grav < 2.0 / Admin plugin). No-op when the
+            // classic Admin plugin isn't installed.
+            'onAdminTwigTemplatePaths' => ['onAdminTwigTemplatePaths', 0],
+
+            // Admin2 / grav-plugin-api (Grav 2.0+). No-op when the API
+            // plugin isn't installed - Grav simply never fires these events.
+            'onApiRegisterRoutes' => ['onApiRegisterRoutes', 0],
+            'onApiSidebarItems' => ['onApiSidebarItems', 0],
+            'onApiPluginPageInfo' => ['onApiPluginPageInfo', 0],
         ];
     }
 
@@ -70,6 +85,7 @@ class PageStatsPlugin extends Plugin
      */
     public function onPluginsInitialized(): void
     {
+        $this->grav['log']->info('page-stats DIAGNOSTIC: onPluginsInitialized fired, isAdmin=' . ($this->isAdmin() ? '1' : '0'));
 
         // Don't proceed if we are in the admin plugin
         if ($this->isAdmin()) {
@@ -96,16 +112,19 @@ class PageStatsPlugin extends Plugin
         $event['paths'] = $paths;
     }
 
-    function getUserIP()
+    function getUserIP(): ?string
     {
         // Get real visitor IP behind CloudFlare network
         if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
             $_SERVER['REMOTE_ADDR'] = $_SERVER["HTTP_CF_CONNECTING_IP"];
             $_SERVER['HTTP_CLIENT_IP'] = $_SERVER["HTTP_CF_CONNECTING_IP"];
         }
-        $client  = @$_SERVER['HTTP_CLIENT_IP'];
-        $forward = @$_SERVER['HTTP_X_FORWARDED_FOR'];
-        $remote  = $_SERVER['REMOTE_ADDR'];
+        $client  = $_SERVER['HTTP_CLIENT_IP'] ?? null;
+        $forward = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? null;
+        // Not every request context has a real client IP (e.g. `bin/grav`
+        // CLI commands such as page-system-validator, which still fire
+        // onPageInitialized). REMOTE_ADDR is simply unset there.
+        $remote  = $_SERVER['REMOTE_ADDR'] ?? null;
 
         if (filter_var($client, FILTER_VALIDATE_IP)) {
             $ip = $client;
@@ -143,11 +162,18 @@ class PageStatsPlugin extends Plugin
     /**
      * returns false if IP (or regexp) are in the plugin config list
      *
-     * @param string $ip
+     * @param string|null $ip
      * @return bool
      */
-    private function isEnabledForIp(string $ip): bool
+    private function isEnabledForIp(?string $ip): bool
     {
+        if ($ip === null) {
+            // No real client IP available (e.g. a CLI context like
+            // `bin/grav page-system-validator`, which still fires
+            // onPageInitialized) - nothing meaningful to log.
+            return false;
+        }
+
         $config  = $this->config();
         if (isset($config['ignored_ips']) && is_array($config['ignored_ips'])) {
             $ips = array_map(function ($a) {
@@ -436,5 +462,73 @@ class PageStatsPlugin extends Plugin
                 $page->init(new \SplFileInfo(__DIR__ . '/pages/recently-viewed-pages.md'));
                 break;
         }
+    }
+
+    /**
+     * Admin2 / grav-plugin-api: registers the REST endpoints consumed by the
+     * Admin2 dashboard page (admin-next/pages/page-stats.js). Fired by the
+     * API plugin's router; never fired if the API plugin isn't installed.
+     */
+    public function onApiRegisterRoutes(Event $event): void
+    {
+        $this->grav['log']->info('page-stats DIAGNOSTIC: onApiRegisterRoutes fired');
+
+        $routes = $event['routes'];
+        $controller = PageStatsApiController::class;
+
+        $routes->group(self::API_PREFIX, function ($group) use ($controller) {
+            $group->get('/overview', [$controller, 'overview']);
+            $group->get('/summary', [$controller, 'summary']);
+            $group->get('/pages', [$controller, 'pages']);
+            $group->get('/pages/detail', [$controller, 'pageDetail']);
+            $group->get('/countries', [$controller, 'countries']);
+            $group->get('/browsers', [$controller, 'browsers']);
+            $group->get('/platforms', [$controller, 'platforms']);
+            $group->get('/users', [$controller, 'users']);
+            $group->get('/users/detail', [$controller, 'userDetail']);
+            $group->get('/recent', [$controller, 'recent']);
+        });
+    }
+
+    /**
+     * Admin2: adds the "Page Stats" entry to the Admin2 sidebar.
+     */
+    public function onApiSidebarItems(Event $event): void
+    {
+        $this->grav['log']->info('page-stats DIAGNOSTIC: onApiSidebarItems fired');
+
+        $items = $event['items'] ?? [];
+        $items[] = [
+            'id' => self::ADMIN2_PAGE_ID,
+            'plugin' => 'page-stats',
+            'label' => $this->grav['language']->translate('PLUGIN_PAGE_STATS.PAGE_STATS'),
+            'icon' => 'fa-line-chart',
+            'route' => self::ADMIN2_ROUTE,
+            'authorize' => ['admin.login', 'admin.super'],
+            'priority' => 10,
+        ];
+        $event['items'] = $items;
+    }
+
+    /**
+     * Admin2: declares the "Page Stats" page as a component-mode page,
+     * rendered by admin-next/pages/page-stats.js.
+     */
+    public function onApiPluginPageInfo(Event $event): void
+    {
+        $this->grav['log']->info('page-stats DIAGNOSTIC: onApiPluginPageInfo fired, plugin=' . ($event['plugin'] ?? 'NULL'));
+
+        if ($event['plugin'] !== 'page-stats') {
+            return;
+        }
+
+        $event['definition'] = [
+            'id' => self::ADMIN2_PAGE_ID,
+            'plugin' => 'page-stats',
+            'title' => $this->grav['language']->translate('PLUGIN_PAGE_STATS.PAGE_STATS'),
+            'icon' => 'fa-line-chart',
+            'page_type' => 'component',
+            'actions' => [],
+        ];
     }
 }


### PR DESCRIPTION
Fixes #53 (https://github.com/francodacosta/grav-plugin-page-stats/issues/53). Adds Admin2 support without touching the classic-admin (Grav < 2.0) code path.

New REST controller (classes/Api/PageStatsApiController.php) exposing the existing Stats data layer via onApiRegisterRoutes
Admin2 sidebar entry + single-page dashboard (admin-next/pages/page-stats.js) via onApiSidebarItems/onApiPluginPageInfo - consolidates the nine classic-admin pages into one dashboard with KPIs, top pages/countries/browsers/platforms/users, recent views, and page/user lookup, since Admin2 component pages are a single route
compatibility block in blueprints.yaml (this is what the migration wizard actually checks - its absence is why the plugin was auto-flagged incompatible)

Along the way, found and fixed several pre-existing bugs in the date-range filtering code path in Stats.php, which appears to have never been exercised with both $dateFrom/$dateTo set at once (see CHANGELOG for details): a TypeError in isEnabledForIp()/getUserIP() when no client IP is available (e.g. CLI commands), a broken date_from/date_to binding in query(), wrong argument order in siteSummary(), and a missing %where in pagesSummary(). Also added PRAGMA busy_timeout/WAL mode to the SQLite connection to avoid request pile-ups under concurrent writes.

Tested live against api plugin v1.0.12 on a real Grav 2.0 site.