### PR TITLE
feat: Page/User Detail views, config tabs, trend charts (develop follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
-# v2.8.0
+# v2.9.0
 ## Unreleased
+
+1. [New Features](#new)
+    * feat: Page Detail / User Detail sub-views. Since Admin2's client-side router only supports a single dynamic path segment per plugin page (no catch-all), sub-views are addressed via query parameters on the fixed plugin route (`?view=page-detail&route=...`, `?view=user-detail&user=...`/`?ip=...`), driven by plain `history.pushState()`/`popstate` - verified to survive a hard reload on all three URL forms and to work correctly with the browser back button. Page Detail shows KPIs, a time-series chart, top countries/browsers/platforms and recent views for a single route; User Detail shows KPIs, a time-series chart, that user's top pages (linked to Page Detail), and their recent views. Both are assembled entirely from the existing dashboard building blocks, no new rendering code. Linked from "Recently viewed pages", "Top users", and both lookup result tables via a small trend icon.
+    * feat: `blueprints.yaml` reorganized into three tabs - General (settings shared by both admin UIs), Grav 1.7 / Classic Admin (the existing per-widget settings, still actively used by the classic templates), and Grav 2.0 / Admin2 (currently an info placeholder for future Admin2-specific options) - keeps the config navigable as both admin UIs continue to be maintained side by side.
+    * feat: time-series trend charts for page views / unique visitors / unique users, and country flags (via flagcdn.com) in the Top Countries widget.
+    * feat: "Recently viewed pages" load-more pagination in 10-row increments (no offset/cursor, avoiding duplicate or missing rows when new hits land between clicks), with Browser and Platform columns added.
+    * feat: IP fallback instead of a plain "(anonymous)" label for hits without a logged-in user, individually traceable via User Detail using `ip` as an alternate key to `user`.
+1. [Bug Fixes](#bugfix)
+    * bugfix: `type: section` blueprint fields require a `title` to render in Admin2 at all (unlike Classic Admin, which renders `text` alone) - several passes fixing empty/invisible info sections in the Admin2 config screen, plus a missing border on empty info boxes.
+    * bugfix: the `collector_ping_interval` blueprint field existed but wasn't actually exposed as an editable field.
+    * bugfix: link ordering and missing/broken links across the recent-pages, lookup, and new detail views, ironed out over several iterations as the detail views took shape.
+    * bugfix: "Load more" button CSS on the recently-viewed-pages list.
+    * bugfix: display error on the page-view detail row.
+1. [Improvements](#improvements)
+    * improvement: database size now shown with a clear label, moved out of an oversized standalone KPI tile into a more compact placement.
+    * docs: added `docs/FORK-NOTES.md`, documenting the fork's branch/tag workflow (`master`/`develop`, dated `develop-YYYY-MM-DD` tags) for anyone picking up maintenance later.
+
+# v2.8.0
+## 08/10/2026
 
 1. [New Features](#new)
     * feat: Grav 2.0 / Admin2 compatibility (#53) - adds a REST API controller (`classes/Api/PageStatsApiController.php`) exposing the existing `Stats` data layer, and an Admin2 sidebar entry + single-page dashboard (`admin-next/pages/page-stats.js`) with page-view/visitor/user totals, top pages/countries/browsers/platforms/users, recently viewed pages, and page/user lookup. Consolidates the nine separate classic-admin pages into one dashboard, since Admin2 component pages are a single route. Requires a `compatibility` declaration in `blueprints.yaml`, which is also what the Grav 2.0 migration wizard checks - its absence is why older versions were auto-flagged as incompatible. Classic Admin (Grav < 2.0) keeps working unchanged via the existing `onAdminDashboard`/`onAdminPage` hooks.

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -13,6 +13,20 @@ const TAG = window.__GRAV_PAGE_TAG || 'grav-page-stats--page-stats';
  * top-browsers / top-platforms / top-users / recently-viewed-pages) into
  * one dashboard with inline lookups, since Admin2 component pages are a
  * single route rather than a set of admin-theme templates.
+ *
+ * Page/User Detail sub-views: Admin2's client-side router only defines a
+ * single dynamic segment for plugin pages (/plugin/[slug]) - no catch-all
+ * for anything deeper, so an actual extra path segment would 404 client-
+ * side on a hard reload. Instead, sub-views live on the exact same route
+ * and are addressed purely via query string (?view=page-detail&route=...),
+ * driven by plain history.pushState()/popstate (this custom element has no
+ * access to SvelteKit's $app/navigation, only the native History API - but
+ * that's what SvelteKit's own helpers wrap anyway, and this route has no
+ * +page.ts load function tied to it, so query-string-only navigation never
+ * triggers SvelteKit's own router). Currently only empty placeholder shells
+ * - the point of this pass is establishing the routing/back-button/deep-
+ * link behaviour and wiring up the overview's links, not the detail
+ * content itself (see docs/FORK-NOTES.md / session notes).
  */
 class PageStatsPage extends HTMLElement {
     #range = '30';
@@ -22,11 +36,94 @@ class PageStatsPage extends HTMLElement {
     #recentLimit = 10;
     #recentPages = [];
     #recentHasMore = true;
+    #view = 'dashboard'; // 'dashboard' | 'page-detail' | 'user-detail'
+    #viewParams = {};
+    #onPopState = null;
 
     connectedCallback() {
         this.attachShadow({ mode: 'open' });
+        this._syncViewFromLocation();
+        this.#onPopState = () => this._handlePopState();
+        window.addEventListener('popstate', this.#onPopState);
         this._render();
-        this._load();
+        if (this.#view === 'dashboard') this._load();
+    }
+
+    disconnectedCallback() {
+        if (this.#onPopState) window.removeEventListener('popstate', this.#onPopState);
+    }
+
+    /**
+     * Reads ?view=...&route=...|user=...|ip=... from the current URL into
+     * #view/#viewParams. Falls back to 'dashboard' for anything malformed
+     * (missing/unknown view, or a detail view without its required param)
+     * rather than showing a broken detail shell.
+     */
+    _syncViewFromLocation() {
+        const params = new URLSearchParams(location.search);
+        const view = params.get('view');
+
+        if (view === 'page-detail' && params.get('route')) {
+            this.#view = 'page-detail';
+            this.#viewParams = { route: params.get('route') };
+            return;
+        }
+        if (view === 'user-detail' && (params.get('user') || params.get('ip'))) {
+            this.#view = 'user-detail';
+            this.#viewParams = params.get('user') ? { user: params.get('user') } : { ip: params.get('ip') };
+            return;
+        }
+        this.#view = 'dashboard';
+        this.#viewParams = {};
+    }
+
+    _handlePopState() {
+        this._syncViewFromLocation();
+        this._render();
+        if (this.#view === 'dashboard') this._load();
+    }
+
+    /**
+     * Internal navigation between the dashboard and a detail sub-view.
+     * Pushes a real history entry (so the browser Back button works) but
+     * never changes the path, only the query string - see class doc
+     * comment for why that matters here.
+     */
+    _navigate(view, params = {}) {
+        this.#view = view;
+        this.#viewParams = params;
+
+        let search = '';
+        if (view !== 'dashboard') {
+            search = `?${new URLSearchParams({ view, ...params }).toString()}`;
+        }
+        history.pushState({ view, params }, '', `${location.pathname}${search}`);
+
+        this._render();
+        if (view === 'dashboard') this._load();
+    }
+
+    /**
+     * Delegated click handling for internal nav links (data-nav="...",
+     * optionally data-nav-route/-user/-ip). Real <a href> elements so
+     * right-click / middle-click / ctrl-click "open in new tab" keeps
+     * working (a fresh tab re-syncs from the URL via _syncViewFromLocation
+     * on connectedCallback); a plain left click is intercepted to do an
+     * in-place SPA navigation instead of a full page reload.
+     */
+    _bindNavLinks(root) {
+        root.querySelectorAll('[data-nav]').forEach((el) => {
+            el.addEventListener('click', (e) => {
+                if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                e.preventDefault();
+                const view = el.dataset.nav;
+                const params = {};
+                if (el.dataset.navRoute) params.route = el.dataset.navRoute;
+                if (el.dataset.navUser) params.user = el.dataset.navUser;
+                if (el.dataset.navIp) params.ip = el.dataset.navIp;
+                this._navigate(view, params);
+            });
+        });
     }
 
     _apiUrl(path) {
@@ -78,6 +175,8 @@ class PageStatsPage extends HTMLElement {
     }
 
     async _load() {
+        if (this.#view !== 'dashboard') return;
+
         this.#loading = true;
         this.#recentLimit = 10;
         this._renderBody();
@@ -107,6 +206,14 @@ class PageStatsPage extends HTMLElement {
     }
 
     _render() {
+        if (this.#view === 'dashboard') {
+            this._renderDashboardShell();
+        } else {
+            this._renderDetailShell();
+        }
+    }
+
+    _renderDashboardShell() {
         this.shadowRoot.innerHTML = `
             <style>${this._styles()}</style>
             <div class="wrap">
@@ -164,6 +271,38 @@ class PageStatsPage extends HTMLElement {
         });
 
         this._highlightRange();
+    }
+
+    /**
+     * Empty skeleton for Page Detail / User Detail. Deliberately just a
+     * back-link + title for now (this pass is about establishing routing/
+     * linking, not the detail content) - see class doc comment.
+     */
+    _renderDetailShell() {
+        this.shadowRoot.innerHTML = `
+            <style>${this._styles()}</style>
+            <div class="wrap">
+                <div class="detail-header">
+                    <a href="${this._esc(location.pathname)}" class="back-link" data-nav="dashboard">&larr; Back to dashboard</a>
+                    <h2>${this._esc(this._detailTitle())}</h2>
+                </div>
+                <div class="card">
+                    <div class="state">This view is coming in a future session - for now it only wires up the URL, back-button and links from the overview.</div>
+                </div>
+            </div>
+        `;
+        this._bindNavLinks(this.shadowRoot);
+    }
+
+    _detailTitle() {
+        if (this.#view === 'page-detail') {
+            return `Page detail: ${this.#viewParams.route || ''}`;
+        }
+        if (this.#view === 'user-detail') {
+            if (this.#viewParams.user) return `User detail: ${this.#viewParams.user}`;
+            if (this.#viewParams.ip) return `User detail: ${this.#viewParams.ip} (anonymous)`;
+        }
+        return '';
     }
 
     _highlightRange() {
@@ -234,7 +373,10 @@ class PageStatsPage extends HTMLElement {
                     <h3>Top users</h3>
                     ${this._table(
                         ['User', 'Hits'],
-                        (o.top_users || []).map((u) => [this._esc(u.user || '(anonymous)'), u.hits])
+                        (o.top_users || []).map((u) => [
+                            u.user ? this._userCellHtml({ user: u.user }) : this._esc('(anonymous)'),
+                            u.hits,
+                        ])
                     )}
                 </div>
 
@@ -243,11 +385,8 @@ class PageStatsPage extends HTMLElement {
                     ${this._table(
                         ['Page', 'User', 'Browser', 'Platform', 'Date'],
                         this.#recentPages.map((r) => [
-                            `<span class="recent-page-cell">
-                                <a href="${this._esc(r.route)}" target="_blank" rel="noopener noreferrer" class="recent-page-link" title="${this._esc(r.route)} in neuem Tab öffnen">${this._externalLinkIcon()}</a>
-                                <span class="recent-page-route" title="${this._esc(r.route)}">${this._esc(r.route)}</span>
-                            </span>`,
-                            this._esc(r.user || r.ip || '(anonymous)'),
+                            this._pageCellHtml(r.route),
+                            this._userCellHtml({ user: r.user, ip: r.ip }),
                             this._esc(r.browser || 'unknown'),
                             this._esc(r.platform || 'unknown'),
                             `${this._esc(r.day || '')} ${this._esc(r.time || '')}`,
@@ -259,6 +398,45 @@ class PageStatsPage extends HTMLElement {
         `;
 
         body.querySelector('.load-more-recent')?.addEventListener('click', () => this._loadMoreRecent());
+        this._bindNavLinks(body);
+    }
+
+    /**
+     * "Page" cell for the Recently viewed pages table: a small trend icon
+     * linking to the (currently empty) Page Detail sub-view, the existing
+     * "open in a new tab" icon linking to the real site page, then the
+     * route text itself (unlinked, see _externalLinkIcon() doc comment for
+     * why the text stays plain). Mirrors the classic-admin 1.7 "Recently
+     * Viewed Pages" widget, which showed the same pair of icons per row.
+     */
+    _pageCellHtml(route) {
+        const encoded = encodeURIComponent(route || '');
+        return `<span class="recent-page-cell">
+            <a href="?view=page-detail&route=${encoded}" class="recent-page-link nav-link" data-nav="page-detail" data-nav-route="${this._esc(route)}" title="View page detail">${this._trendIcon()}</a>
+            <a href="${this._esc(route)}" target="_blank" rel="noopener noreferrer" class="recent-page-link" title="${this._esc(route)} in neuem Tab öffnen">${this._externalLinkIcon()}</a>
+            <span class="recent-page-route" title="${this._esc(route)}">${this._esc(route)}</span>
+        </span>`;
+    }
+
+    /**
+     * "User" cell shared by Recently viewed pages and Top users: a trend
+     * icon linking to User Detail plus the label. Links by username when
+     * available; falls back to linking by IP for anonymous-but-identifiable
+     * visitors (see PageStatsApiController::userDetail(), which accepts
+     * either param). Pass neither (Top users' aggregated anonymous bucket)
+     * to get a plain, unlinked "(anonymous)" label.
+     */
+    _userCellHtml({ user, ip } = {}) {
+        const label = user || ip || '(anonymous)';
+        if (!user && !ip) {
+            return this._esc(label);
+        }
+        const param = user ? `user=${encodeURIComponent(user)}` : `ip=${encodeURIComponent(ip)}`;
+        const navAttr = user ? `data-nav-user="${this._esc(user)}"` : `data-nav-ip="${this._esc(ip)}"`;
+        return `<span class="recent-page-cell">
+            <a href="?view=user-detail&${param}" class="recent-page-link nav-link" data-nav="user-detail" ${navAttr} title="View user detail">${this._trendIcon()}</a>
+            <span class="recent-page-route">${this._esc(label)}</span>
+        </span>`;
     }
 
     /**
@@ -469,6 +647,18 @@ class PageStatsPage extends HTMLElement {
         </svg>`;
     }
 
+    /**
+     * Small "trending up" glyph used as the Page/User Detail link icon in
+     * "Recently viewed pages" and "Top users" - the same role the small
+     * chart icon played next to each row in the classic-admin 1.7 widget.
+     */
+    _trendIcon() {
+        return `<svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+            <path d="M2 12 6 7 9 9.5 14 3" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"></path>
+            <path d="M10.5 3H14v3.5" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>`;
+    }
+
     _bars(items, key) {
         if (!items || !items.length) return `<div class="state">No data.</div>`;
         const max = Math.max(...items.map((i) => Number(i.hits) || 0), 1);
@@ -593,6 +783,10 @@ class PageStatsPage extends HTMLElement {
             .recent-page-link:hover { color: var(--foreground); }
             .recent-page-route { color: var(--foreground); }
             .load-more-recent { display: block; margin-top: 12px; }
+            .detail-header { display: flex; flex-direction: column; gap: 6px; margin-bottom: 4px; }
+            .back-link { color: var(--muted-foreground); text-decoration: none; font-size: 13px; align-self: flex-start; }
+            .back-link:hover { color: var(--foreground); }
+            .detail-header h2 { margin: 0; font-size: 16px; font-weight: 600; word-break: break-all; }
             .state { color: var(--muted-foreground); font-size: 13px; padding: 8px 0; }
             .state.error { color: var(--destructive, #dc2626); }
             .lookup { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 12px; }

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -492,6 +492,7 @@ class PageStatsPage extends HTMLElement {
         return `
             :host { display: block; color: var(--foreground); font-family: inherit; padding-top: 16px; }
             .wrap { display: flex; flex-direction: column; gap: 16px; }
+            .body { display: flex; flex-direction: column; gap: 16px; }
             .toolbar { display: flex; justify-content: space-between; align-items: center; }
             .range { display: flex; gap: 4px; }
             .range button, .refresh, .lookup-row button {
@@ -508,6 +509,17 @@ class PageStatsPage extends HTMLElement {
             .kpi { border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; display: flex; flex-direction: column; align-items: center; }
             .kpi-value { font-size: 22px; font-weight: 700; }
             .kpi-label { font-size: 12px; color: var(--muted-foreground); margin-top: 4px; }
+            .charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 12px; }
+            .chart-card { display: flex; flex-direction: column; }
+            .chart-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
+            .chart-head h3 { margin: 0; }
+            .chart-total { font-size: 15px; font-weight: 700; }
+            .line-chart { display: block; width: 100%; height: auto; }
+            .grid-line { stroke: var(--border); stroke-width: 1; }
+            .axis-label { font-size: 9px; fill: var(--muted-foreground); }
+            .chart-area { fill: currentColor; opacity: 0.15; stroke: none; }
+            .chart-line { fill: none; stroke: currentColor; stroke-width: 1.75; }
+            .chart-dot { fill: currentColor; }
             .sparkline { width: 100%; height: 36px; margin-top: 10px; }
             .spark-area { fill: var(--primary); opacity: 0.12; }
             .spark-line { fill: none; stroke: var(--primary); stroke-width: 1.5; }

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -184,10 +184,13 @@ class PageStatsPage extends HTMLElement {
         const usersSeries = this._buildDailySeries(this.#summary?.users, from, to);
 
         body.innerHTML = `
+            <div class="charts">
+                ${this._chartCard('Page views', o.total_page_views, hitsSeries, 'var(--primary)')}
+                ${this._chartCard('Unique visitors', o.total_unique_visitors, visitorsSeries, '#22d3ee')}
+                ${this._chartCard('Unique users', o.total_unique_users, usersSeries, '#f59e0b')}
+            </div>
+
             <div class="kpis">
-                ${this._kpi('Page views', o.total_page_views, hitsSeries)}
-                ${this._kpi('Unique visitors', o.total_unique_visitors, visitorsSeries)}
-                ${this._kpi('Unique users', o.total_unique_users, usersSeries)}
                 ${this._kpi('Database size', `${o.db?.mb ?? 0} MB`)}
             </div>
 
@@ -242,14 +245,107 @@ class PageStatsPage extends HTMLElement {
         `;
     }
 
-    _kpi(label, value, series) {
-        const spark = series && series.length > 1 ? this._sparkline(series) : '';
+    _kpi(label, value) {
         return `
             <div class="kpi">
                 <div class="kpi-value">${this._esc(String(value ?? '0'))}</div>
                 <div class="kpi-label">${this._esc(label)}</div>
-                ${spark}
             </div>`;
+    }
+
+    _chartCard(title, total, series, color) {
+        const chart = series.length ? this._lineChart(series, color) : `<div class="state">No data.</div>`;
+        return `
+            <div class="card chart-card">
+                <div class="chart-head">
+                    <h3>${this._esc(title)}</h3>
+                    <span class="chart-total">${this._esc(String(total ?? '0'))}</span>
+                </div>
+                ${chart}
+            </div>`;
+    }
+
+    /**
+     * 'YYYY-MM-DD' -> 'DD.MM.' for compact axis labels.
+     */
+    _formatDayLabel(iso) {
+        const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso || '');
+        return m ? `${m[3]}.${m[2]}.` : iso || '';
+    }
+
+    /**
+     * A proper axis chart (y-axis gridlines/labels, x-axis date labels,
+     * hover tooltips via native SVG <title> per point) rather than a bare
+     * sparkline - closer to what the classic-admin version of this plugin
+     * showed (three full charts with axes), while still fitting a
+     * dashboard card instead of a whole separate admin page.
+     */
+    _lineChart(series, color) {
+        const width = 480;
+        const height = 170;
+        const padLeft = 34;
+        const padRight = 8;
+        const padTop = 10;
+        const padBottom = 20;
+        const plotW = width - padLeft - padRight;
+        const plotH = height - padTop - padBottom;
+
+        const max = Math.max(...series.map((p) => p.value), 1);
+        const yTickCount = 4;
+        const yTicks = Array.from({ length: yTickCount + 1 }, (_, i) => Math.round((max / yTickCount) * i));
+
+        const stepX = series.length > 1 ? plotW / (series.length - 1) : plotW;
+        const points = series.map((p, i) => ({
+            ...p,
+            x: padLeft + i * stepX,
+            y: padTop + plotH - (p.value / max) * plotH,
+        }));
+
+        const linePath = `M${points.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' L')}`;
+        const baseline = (padTop + plotH).toFixed(1);
+        const areaPath = `${linePath} L${points[points.length - 1].x.toFixed(1)},${baseline} L${points[0].x.toFixed(1)},${baseline} Z`;
+
+        const gridlines = yTicks
+            .map((v) => {
+                const y = padTop + plotH - (v / max) * plotH;
+                return `
+                    <line class="grid-line" x1="${padLeft}" y1="${y.toFixed(1)}" x2="${width - padRight}" y2="${y.toFixed(1)}"></line>
+                    <text class="axis-label y-label" x="${padLeft - 6}" y="${(y + 3).toFixed(1)}" text-anchor="end">${v}</text>`;
+            })
+            .join('');
+
+        // A handful of evenly spaced x-axis labels rather than one per day -
+        // that many labels overlap on anything but a 7-day range.
+        const labelCount = Math.min(6, points.length);
+        const labelStep = points.length > 1 ? (points.length - 1) / Math.max(1, labelCount - 1) : 0;
+        const seenX = new Set();
+        const xAxisLabels = Array.from({ length: labelCount }, (_, i) => points[Math.round(i * labelStep)])
+            .filter((p) => {
+                if (seenX.has(p.x)) return false;
+                seenX.add(p.x);
+                return true;
+            })
+            .map(
+                (p) =>
+                    `<text class="axis-label x-label" x="${p.x.toFixed(1)}" y="${height - 4}" text-anchor="middle">${this._esc(this._formatDayLabel(p.date))}</text>`
+            )
+            .join('');
+
+        const dots = points
+            .map(
+                (p) =>
+                    `<circle class="chart-dot" cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="2.5"><title>${this._esc(this._formatDayLabel(p.date))}: ${p.value}</title></circle>`
+            )
+            .join('');
+
+        return `
+            <svg class="line-chart" viewBox="0 0 ${width} ${height}" style="color:${color}">
+                ${gridlines}
+                <path class="chart-area" d="${areaPath}"></path>
+                <path class="chart-line" d="${linePath}"></path>
+                ${dots}
+                ${xAxisLabels}
+            </svg>`;
     }
 
     /**
@@ -287,35 +383,37 @@ class PageStatsPage extends HTMLElement {
         return series;
     }
 
-    _sparkline(series, width = 160, height = 36) {
-        const max = Math.max(...series.map((p) => p.value), 1);
-        const stepX = series.length > 1 ? width / (series.length - 1) : width;
-        const points = series.map((p, i) => {
-            const x = i * stepX;
-            const y = height - (p.value / max) * height;
-            return `${x.toFixed(1)},${y.toFixed(1)}`;
-        });
-        const linePath = `M${points.join(' L')}`;
-        const areaPath = `${linePath} L${width},${height} L0,${height} Z`;
-        return `
-            <svg class="sparkline" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
-                <path class="spark-area" d="${areaPath}"></path>
-                <path class="spark-line" d="${linePath}"></path>
-            </svg>`;
-    }
-
     /**
      * Converts a 2-letter ISO country code (as stored by Geolocation /
      * classes/Stats.php: $geo->countryCode(), empty falls back to the
-     * literal string "unknown") into a flag emoji via Unicode regional
-     * indicator symbols. Anything that isn't a clean 2-letter code
-     * (including "unknown") falls back to a globe icon rather than
-     * guessing.
+     * literal string "unknown") into a small flag image.
+     *
+     * Deliberately NOT using the Unicode "flag" emoji (combined regional
+     * indicator symbols) here: whether that renders as an actual flag
+     * depends entirely on the OS/browser having a matching color-emoji
+     * font installed, and on several common desktop Linux setups it just
+     * shows as two plain letters or a blank box. An <img> renders
+     * consistently everywhere. flagcdn.com is the same kind of external,
+     * free flag source the classic-admin version of this plugin used
+     * (flagpedia.net, per its README credits) - current CSP
+     * (img-src 'self' https:, both public and /admin blocks, see
+     * grav-chat-2026-07-18-user-folder-exposure-csp-htaccess.md) already
+     * allows this without further Apache changes.
      */
-    _flagEmoji(code) {
-        if (typeof code !== 'string' || !/^[A-Za-z]{2}$/.test(code)) return '\u{1F310}';
-        const codePoints = [...code.toUpperCase()].map((c) => 0x1f1e6 + (c.charCodeAt(0) - 65));
-        return String.fromCodePoint(...codePoints);
+    _flagIcon(code) {
+        if (typeof code === 'string' && /^[A-Za-z]{2}$/.test(code)) {
+            const lower = code.toLowerCase();
+            return `<img class="bar-flag" src="https://flagcdn.com/${lower}.svg" alt="${this._esc(code.toUpperCase())}" loading="lazy" width="18" height="13">`;
+        }
+        return `<span class="bar-flag bar-flag-unknown" title="Unknown">${this._globeIcon()}</span>`;
+    }
+
+    _globeIcon() {
+        return `<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+            <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.2"></circle>
+            <ellipse cx="8" cy="8" rx="3" ry="7" fill="none" stroke="currentColor" stroke-width="1.2"></ellipse>
+            <line x1="1" y1="8" x2="15" y2="8" stroke="currentColor" stroke-width="1.2"></line>
+        </svg>`;
     }
 
     _bars(items, key) {
@@ -324,7 +422,7 @@ class PageStatsPage extends HTMLElement {
         return `<div class="bars">${items
             .map((i) => {
                 const pct = Math.max(4, Math.round(((Number(i.hits) || 0) / max) * 100));
-                const flag = key === 'country' ? `<span class="bar-flag">${this._flagEmoji(i[key])}</span>` : '';
+                const flag = key === 'country' ? this._flagIcon(i[key]) : '';
                 return `
                     <div class="bar-row">
                         <span class="bar-label">${flag}${this._esc(String(i[key] || 'unknown'))}</span>

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -17,6 +17,7 @@ const TAG = window.__GRAV_PAGE_TAG || 'grav-page-stats--page-stats';
 class PageStatsPage extends HTMLElement {
     #range = '30';
     #overview = null;
+    #summary = null;
     #loading = false;
 
     connectedCallback() {
@@ -50,12 +51,23 @@ class PageStatsPage extends HTMLElement {
         return json.data !== undefined ? json.data : json;
     }
 
-    _dateRangeParams() {
-        if (this.#range === 'all') return {};
+    /**
+     * @returns {{from: Date|null, to: Date|null}} 'all time' is represented
+     * as {from: null, to: null} - there's no meaningful start date to zero-fill
+     * a chart from.
+     */
+    _currentDateRange() {
+        if (this.#range === 'all') return { from: null, to: null };
         const days = parseInt(this.#range, 10);
         const to = new Date();
         const from = new Date();
         from.setDate(from.getDate() - days);
+        return { from, to };
+    }
+
+    _dateRangeParams() {
+        const { from, to } = this._currentDateRange();
+        if (!from || !to) return {};
         return {
             date_from: from.toISOString(),
             date_to: to.toISOString(),
@@ -65,16 +77,27 @@ class PageStatsPage extends HTMLElement {
     async _load() {
         this.#loading = true;
         this._renderBody();
-        try {
-            this.#overview = await this._apiGet('/page-stats/overview', this._dateRangeParams());
-        } catch (err) {
-            this.#overview = null;
-            this._error = err.message;
-            window.__GRAV_TOAST?.error(err.message || 'Could not load page stats');
-        } finally {
-            this.#loading = false;
-            this._renderBody();
+
+        const params = this._dateRangeParams();
+        const [overviewResult, summaryResult] = await Promise.allSettled([
+            this._apiGet('/page-stats/overview', params),
+            this._apiGet('/page-stats/summary', params),
+        ]);
+
+        this.#overview = overviewResult.status === 'fulfilled' ? overviewResult.value : null;
+        this.#summary = summaryResult.status === 'fulfilled' ? summaryResult.value : null;
+
+        if (overviewResult.status === 'rejected') {
+            this._error = overviewResult.reason?.message || 'Could not load page stats';
+            window.__GRAV_TOAST?.error(this._error);
+        } else if (summaryResult.status === 'rejected') {
+            // Non-fatal: the KPI numbers and top lists come from /overview
+            // and still work, only the trend sparklines are missing.
+            window.__GRAV_TOAST?.error(summaryResult.reason?.message || 'Could not load trend data');
         }
+
+        this.#loading = false;
+        this._renderBody();
     }
 
     _render() {
@@ -155,12 +178,16 @@ class PageStatsPage extends HTMLElement {
         }
 
         const o = this.#overview;
+        const { from, to } = this._currentDateRange();
+        const hitsSeries = this._buildDailySeries(this.#summary?.hits, from, to);
+        const visitorsSeries = this._buildDailySeries(this.#summary?.visitors, from, to);
+        const usersSeries = this._buildDailySeries(this.#summary?.users, from, to);
 
         body.innerHTML = `
             <div class="kpis">
-                ${this._kpi('Page views', o.total_page_views)}
-                ${this._kpi('Unique visitors', o.total_unique_visitors)}
-                ${this._kpi('Unique users', o.total_unique_users)}
+                ${this._kpi('Page views', o.total_page_views, hitsSeries)}
+                ${this._kpi('Unique visitors', o.total_unique_visitors, visitorsSeries)}
+                ${this._kpi('Unique users', o.total_unique_users, usersSeries)}
                 ${this._kpi('Database size', `${o.db?.mb ?? 0} MB`)}
             </div>
 
@@ -215,8 +242,80 @@ class PageStatsPage extends HTMLElement {
         `;
     }
 
-    _kpi(label, value) {
-        return `<div class="kpi"><div class="kpi-value">${this._esc(String(value ?? '0'))}</div><div class="kpi-label">${this._esc(label)}</div></div>`;
+    _kpi(label, value, series) {
+        const spark = series && series.length > 1 ? this._sparkline(series) : '';
+        return `
+            <div class="kpi">
+                <div class="kpi-value">${this._esc(String(value ?? '0'))}</div>
+                <div class="kpi-label">${this._esc(label)}</div>
+                ${spark}
+            </div>`;
+    }
+
+    /**
+     * Turns the raw rows from Stats::siteSummary() (one row per day *that
+     * has data*, in no guaranteed order - see classes/Stats.php) into a
+     * chronologically sorted array of {date, value}. When we know the
+     * selected range (from/to), missing days are filled in with 0 so the
+     * sparkline has an evenly spaced timeline instead of gaps wherever a
+     * day had zero visits. For 'all time' (from/to unknown) we just sort
+     * whatever days came back, without filling - the range could span
+     * years and the exact start date isn't known client-side.
+     */
+    _buildDailySeries(rows, from, to) {
+        const byDate = new Map();
+        (rows || []).forEach((r) => {
+            if (r && r.date) byDate.set(r.date, Number(r.hits) || 0);
+        });
+
+        if (!from || !to) {
+            return [...byDate.entries()]
+                .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+                .map(([date, value]) => ({ date, value }));
+        }
+
+        const series = [];
+        const cursor = new Date(from);
+        cursor.setHours(0, 0, 0, 0);
+        const end = new Date(to);
+        end.setHours(0, 0, 0, 0);
+        while (cursor <= end) {
+            const key = cursor.toISOString().slice(0, 10);
+            series.push({ date: key, value: byDate.get(key) || 0 });
+            cursor.setDate(cursor.getDate() + 1);
+        }
+        return series;
+    }
+
+    _sparkline(series, width = 160, height = 36) {
+        const max = Math.max(...series.map((p) => p.value), 1);
+        const stepX = series.length > 1 ? width / (series.length - 1) : width;
+        const points = series.map((p, i) => {
+            const x = i * stepX;
+            const y = height - (p.value / max) * height;
+            return `${x.toFixed(1)},${y.toFixed(1)}`;
+        });
+        const linePath = `M${points.join(' L')}`;
+        const areaPath = `${linePath} L${width},${height} L0,${height} Z`;
+        return `
+            <svg class="sparkline" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
+                <path class="spark-area" d="${areaPath}"></path>
+                <path class="spark-line" d="${linePath}"></path>
+            </svg>`;
+    }
+
+    /**
+     * Converts a 2-letter ISO country code (as stored by Geolocation /
+     * classes/Stats.php: $geo->countryCode(), empty falls back to the
+     * literal string "unknown") into a flag emoji via Unicode regional
+     * indicator symbols. Anything that isn't a clean 2-letter code
+     * (including "unknown") falls back to a globe icon rather than
+     * guessing.
+     */
+    _flagEmoji(code) {
+        if (typeof code !== 'string' || !/^[A-Za-z]{2}$/.test(code)) return '\u{1F310}';
+        const codePoints = [...code.toUpperCase()].map((c) => 0x1f1e6 + (c.charCodeAt(0) - 65));
+        return String.fromCodePoint(...codePoints);
     }
 
     _bars(items, key) {
@@ -225,9 +324,10 @@ class PageStatsPage extends HTMLElement {
         return `<div class="bars">${items
             .map((i) => {
                 const pct = Math.max(4, Math.round(((Number(i.hits) || 0) / max) * 100));
+                const flag = key === 'country' ? `<span class="bar-flag">${this._flagEmoji(i[key])}</span>` : '';
                 return `
                     <div class="bar-row">
-                        <span class="bar-label">${this._esc(String(i[key] || 'unknown'))}</span>
+                        <span class="bar-label">${flag}${this._esc(String(i[key] || 'unknown'))}</span>
                         <div class="bar-track"><div class="bar-fill" style="width:${pct}%"></div></div>
                         <span class="bar-value">${this._esc(String(i.hits))}${i.share !== undefined ? ` (${i.share}%)` : ''}</span>
                     </div>`;
@@ -292,7 +392,7 @@ class PageStatsPage extends HTMLElement {
 
     _styles() {
         return `
-            :host { display: block; color: var(--foreground); font-family: inherit; }
+            :host { display: block; color: var(--foreground); font-family: inherit; padding-top: 16px; }
             .wrap { display: flex; flex-direction: column; gap: 16px; }
             .toolbar { display: flex; justify-content: space-between; align-items: center; }
             .range { display: flex; gap: 4px; }
@@ -307,9 +407,12 @@ class PageStatsPage extends HTMLElement {
             }
             .range button.active { background: var(--primary); color: var(--primary-foreground, #fff); border-color: var(--primary); }
             .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
-            .kpi { border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
+            .kpi { border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; display: flex; flex-direction: column; align-items: center; }
             .kpi-value { font-size: 22px; font-weight: 700; }
             .kpi-label { font-size: 12px; color: var(--muted-foreground); margin-top: 4px; }
+            .sparkline { width: 100%; height: 36px; margin-top: 10px; }
+            .spark-area { fill: var(--primary); opacity: 0.12; }
+            .spark-line { fill: none; stroke: var(--primary); stroke-width: 1.5; }
             .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 12px; }
             .card { border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
             .card.wide { grid-column: 1 / -1; }
@@ -320,6 +423,7 @@ class PageStatsPage extends HTMLElement {
             .bars { display: flex; flex-direction: column; gap: 8px; }
             .bar-row { display: grid; grid-template-columns: 90px 1fr 70px; align-items: center; gap: 8px; font-size: 13px; }
             .bar-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+            .bar-flag { margin-right: 4px; }
             .bar-track { background: var(--border); border-radius: 4px; height: 8px; overflow: hidden; }
             .bar-fill { background: var(--primary); height: 100%; }
             .bar-value { text-align: right; color: var(--muted-foreground); }

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -19,6 +19,9 @@ class PageStatsPage extends HTMLElement {
     #overview = null;
     #summary = null;
     #loading = false;
+    #recentLimit = 10;
+    #recentPages = [];
+    #recentHasMore = true;
 
     connectedCallback() {
         this.attachShadow({ mode: 'open' });
@@ -76,6 +79,7 @@ class PageStatsPage extends HTMLElement {
 
     async _load() {
         this.#loading = true;
+        this.#recentLimit = 10;
         this._renderBody();
 
         const params = this._dateRangeParams();
@@ -86,6 +90,8 @@ class PageStatsPage extends HTMLElement {
 
         this.#overview = overviewResult.status === 'fulfilled' ? overviewResult.value : null;
         this.#summary = summaryResult.status === 'fulfilled' ? summaryResult.value : null;
+        this.#recentPages = this.#overview?.recent_pages || [];
+        this.#recentHasMore = this.#recentPages.length >= this.#recentLimit;
 
         if (overviewResult.status === 'rejected') {
             this._error = overviewResult.reason?.message || 'Could not load page stats';
@@ -235,16 +241,44 @@ class PageStatsPage extends HTMLElement {
                 <div class="card wide">
                     <h3>Recently viewed pages</h3>
                     ${this._table(
-                        ['Route', 'User', 'Date'],
-                        (o.recent_pages || []).map((r) => [
-                            this._esc(r.route),
+                        ['Page', 'User', 'Browser', 'Platform', 'Date'],
+                        this.#recentPages.map((r) => [
+                            `<a href="${this._esc(r.route)}" target="_blank" rel="noopener noreferrer" title="${this._esc(r.route)}">${this._esc(r.route)}</a>`,
                             this._esc(r.user || '(anonymous)'),
+                            this._esc(r.browser || 'unknown'),
+                            this._esc(r.platform || 'unknown'),
                             `${this._esc(r.day || '')} ${this._esc(r.time || '')}`,
                         ])
                     )}
+                    ${this.#recentPages.length && this.#recentHasMore ? `<button class="load-more-recent">Load more</button>` : ''}
                 </div>
             </div>
         `;
+
+        body.querySelector('.load-more-recent')?.addEventListener('click', () => this._loadMoreRecent());
+    }
+
+    /**
+     * Re-requests /page-stats/recent with a larger `limit` (10 -> 20 -> 30 ...)
+     * and re-renders just the body. Deliberately not an offset/cursor-based
+     * pagination: re-fetching the whole newest-first list with a bigger
+     * limit avoids duplicate/missing rows if new hits arrive between clicks,
+     * and needs no extra server-side state.
+     */
+    async _loadMoreRecent() {
+        const nextLimit = this.#recentLimit + 10;
+        try {
+            const data = await this._apiGet('/page-stats/recent', {
+                ...this._dateRangeParams(),
+                limit: nextLimit,
+            });
+            this.#recentPages = data.pages || [];
+            this.#recentLimit = nextLimit;
+            this.#recentHasMore = this.#recentPages.length >= nextLimit;
+        } catch (err) {
+            window.__GRAV_TOAST?.error(err.message || 'Could not load more recently viewed pages');
+        }
+        this._renderBody();
     }
 
     _chartCard(title, total, series, color) {

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -182,7 +182,7 @@ class PageStatsPage extends HTMLElement {
 
         const o = this.#overview;
         const dbBadge = this.shadowRoot.querySelector('.db-size');
-        if (dbBadge) dbBadge.textContent = o.db?.mb !== undefined ? `${o.db.mb} MB` : '';
+        if (dbBadge) dbBadge.textContent = o.db?.mb !== undefined ? `Database size: ${o.db.mb} MB` : '';
 
         const { from, to } = this._currentDateRange();
         const hitsSeries = this._buildDailySeries(this.#summary?.hits, from, to);

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -541,7 +541,7 @@ class PageStatsPage extends HTMLElement {
             .body { display: flex; flex-direction: column; gap: 16px; }
             .toolbar { display: flex; justify-content: space-between; align-items: center; }
             .range { display: flex; gap: 4px; }
-            .range button, .refresh, .lookup-row button {
+            .range button, .refresh, .lookup-row button, .load-more-recent {
                 background: var(--background);
                 color: var(--foreground);
                 border: 1px solid var(--border);
@@ -585,6 +585,7 @@ class PageStatsPage extends HTMLElement {
             .recent-page-link { color: var(--muted-foreground); display: inline-flex; text-decoration: none; }
             .recent-page-link:hover { color: var(--foreground); }
             .recent-page-route { color: var(--foreground); }
+            .load-more-recent { display: block; margin-top: 12px; }
             .state { color: var(--muted-foreground); font-size: 13px; padding: 8px 0; }
             .state.error { color: var(--destructive, #dc2626); }
             .lookup { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 12px; }

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -243,8 +243,11 @@ class PageStatsPage extends HTMLElement {
                     ${this._table(
                         ['Page', 'User', 'Browser', 'Platform', 'Date'],
                         this.#recentPages.map((r) => [
-                            `<a href="${this._esc(r.route)}" target="_blank" rel="noopener noreferrer" title="${this._esc(r.route)}">${this._esc(r.route)}</a>`,
-                            this._esc(r.user || '(anonymous)'),
+                            `<span class="recent-page-cell">
+                                <a href="${this._esc(r.route)}" target="_blank" rel="noopener noreferrer" class="recent-page-link" title="${this._esc(r.route)} in neuem Tab öffnen">${this._externalLinkIcon()}</a>
+                                <span class="recent-page-route" title="${this._esc(r.route)}">${this._esc(r.route)}</span>
+                            </span>`,
+                            this._esc(r.user || r.ip || '(anonymous)'),
                             this._esc(r.browser || 'unknown'),
                             this._esc(r.platform || 'unknown'),
                             `${this._esc(r.day || '')} ${this._esc(r.time || '')}`,
@@ -444,6 +447,21 @@ class PageStatsPage extends HTMLElement {
         </svg>`;
     }
 
+    /**
+     * Small "open in new tab" glyph used in front of a route in the
+     * "Recently viewed pages" table. Deliberately only this icon is
+     * wrapped in the <a>, not the route text itself - a full-text link
+     * would pick up the browser's default link color/underline, which
+     * looks out of place next to plain-text table cells (route text stays
+     * themed via .recent-page-route, see _styles()).
+     */
+    _externalLinkIcon() {
+        return `<svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+            <path d="M6.5 3H3.5A1.5 1.5 0 0 0 2 4.5v8A1.5 1.5 0 0 0 3.5 14h8a1.5 1.5 0 0 0 1.5-1.5V9.5" fill="none" stroke="currentColor" stroke-width="1.3"></path>
+            <path d="M9.5 2H14v4.5M14 2 7 9" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>`;
+    }
+
     _bars(items, key) {
         if (!items || !items.length) return `<div class="state">No data.</div>`;
         const max = Math.max(...items.map((i) => Number(i.hits) || 0), 1);
@@ -563,6 +581,10 @@ class PageStatsPage extends HTMLElement {
             .bar-track { background: var(--border); border-radius: 4px; height: 8px; overflow: hidden; }
             .bar-fill { background: var(--primary); height: 100%; }
             .bar-value { text-align: right; color: var(--muted-foreground); }
+            .recent-page-cell { display: inline-flex; align-items: center; gap: 6px; }
+            .recent-page-link { color: var(--muted-foreground); display: inline-flex; text-decoration: none; }
+            .recent-page-link:hover { color: var(--foreground); }
+            .recent-page-route { color: var(--foreground); }
             .state { color: var(--muted-foreground); font-size: 13px; padding: 8px 0; }
             .state.error { color: var(--destructive, #dc2626); }
             .lookup { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 12px; }

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -23,10 +23,10 @@ const TAG = window.__GRAV_PAGE_TAG || 'grav-page-stats--page-stats';
  * access to SvelteKit's $app/navigation, only the native History API - but
  * that's what SvelteKit's own helpers wrap anyway, and this route has no
  * +page.ts load function tied to it, so query-string-only navigation never
- * triggers SvelteKit's own router). Currently only empty placeholder shells
- * - the point of this pass is establishing the routing/back-button/deep-
- * link behaviour and wiring up the overview's links, not the detail
- * content itself (see docs/FORK-NOTES.md / session notes).
+ * triggers SvelteKit's own router). Page/User Detail reuse the same chart/
+ * bars/table building blocks as the dashboard, filtered server-side by
+ * route/user/ip (see PageStatsApiController::pageDetail()/userDetail()/
+ * summary()).
  */
 class PageStatsPage extends HTMLElement {
     #range = '30';
@@ -46,7 +46,7 @@ class PageStatsPage extends HTMLElement {
         this.#onPopState = () => this._handlePopState();
         window.addEventListener('popstate', this.#onPopState);
         this._render();
-        if (this.#view === 'dashboard') this._load();
+        this._load();
     }
 
     disconnectedCallback() {
@@ -80,7 +80,7 @@ class PageStatsPage extends HTMLElement {
     _handlePopState() {
         this._syncViewFromLocation();
         this._render();
-        if (this.#view === 'dashboard') this._load();
+        this._load();
     }
 
     /**
@@ -100,7 +100,7 @@ class PageStatsPage extends HTMLElement {
         history.pushState({ view, params }, '', `${location.pathname}${search}`);
 
         this._render();
-        if (view === 'dashboard') this._load();
+        this._load();
     }
 
     /**
@@ -175,8 +175,12 @@ class PageStatsPage extends HTMLElement {
     }
 
     async _load() {
-        if (this.#view !== 'dashboard') return;
+        if (this.#view === 'page-detail') return this._loadPageDetail();
+        if (this.#view === 'user-detail') return this._loadUserDetail();
+        return this._loadDashboard();
+    }
 
+    async _loadDashboard() {
         this.#loading = true;
         this.#recentLimit = 10;
         this._renderBody();
@@ -203,6 +207,129 @@ class PageStatsPage extends HTMLElement {
 
         this.#loading = false;
         this._renderBody();
+    }
+
+    _detailBodyEl() {
+        return this.shadowRoot.querySelector('.detail-body');
+    }
+
+    /**
+     * Page Detail: KPI + trend chart + Top countries/browsers/platforms,
+     * all filtered server-side to this one route, plus the raw recent
+     * views list. Mirrors the classic-admin 1.7 page-details.html.twig
+     * widget set (see grav-chat-2026-07-26-page-stats-blueprint-config-tabs.md,
+     * Teil 2) using the same building blocks as the dashboard.
+     */
+    async _loadPageDetail() {
+        const body = this._detailBodyEl();
+        if (!body) return;
+        body.innerHTML = `<div class="state">Loading…</div>`;
+
+        const route = this.#viewParams.route;
+        const params = { ...this._dateRangeParams(), route, limit: 100 };
+        const [detailResult, summaryResult] = await Promise.allSettled([
+            this._apiGet('/page-stats/pages/detail', params),
+            this._apiGet('/page-stats/summary', params),
+        ]);
+
+        if (detailResult.status === 'rejected') {
+            body.innerHTML = `<div class="state error">${this._esc(detailResult.reason?.message || 'Could not load page detail')}</div>`;
+            return;
+        }
+
+        const d = detailResult.value;
+        const summary = summaryResult.status === 'fulfilled' ? summaryResult.value : null;
+        const { from, to } = this._currentDateRange();
+        const hitsSeries = this._buildDailySeries(summary?.hits, from, to);
+
+        body.innerHTML = `
+            <div class="charts">
+                ${this._chartCard('Page views', d.hits, hitsSeries, 'var(--primary)')}
+            </div>
+            <div class="grid">
+                <div class="card">
+                    <h3>Top countries</h3>
+                    ${this._bars(d.top_countries, 'country')}
+                </div>
+                <div class="card">
+                    <h3>Top browsers</h3>
+                    ${this._bars(d.top_browsers, 'browser')}
+                </div>
+                <div class="card">
+                    <h3>Top platforms</h3>
+                    ${this._bars(d.top_platforms, 'platform')}
+                </div>
+                <div class="card wide">
+                    <h3>Recent views (${this._esc(String(d.hits))} hits, ${this._esc(String(d.visitors))} unique visitors)</h3>
+                    ${this._table(
+                        ['User', 'Browser', 'Platform', 'Date'],
+                        (d.views || []).map((v) => [
+                            this._userCellHtml({ user: v.user, ip: v.ip }),
+                            this._esc(v.browser || 'unknown'),
+                            this._esc(v.platform || 'unknown'),
+                            `${this._esc(v.day || '')} ${this._esc(v.time || '')}`,
+                        ])
+                    )}
+                </div>
+            </div>
+        `;
+        this._bindNavLinks(body);
+    }
+
+    /**
+     * User Detail: KPI + trend chart + Top pages visited, filtered
+     * server-side to this one user/IP, plus the raw recent views list.
+     * Mirrors the classic-admin 1.7 user-details.html.twig widget set.
+     */
+    async _loadUserDetail() {
+        const body = this._detailBodyEl();
+        if (!body) return;
+        body.innerHTML = `<div class="state">Loading…</div>`;
+
+        const identity = this.#viewParams.user ? { user: this.#viewParams.user } : { ip: this.#viewParams.ip };
+        const params = { ...this._dateRangeParams(), ...identity, limit: 100 };
+        const [detailResult, summaryResult] = await Promise.allSettled([
+            this._apiGet('/page-stats/users/detail', params),
+            this._apiGet('/page-stats/summary', params),
+        ]);
+
+        if (detailResult.status === 'rejected') {
+            body.innerHTML = `<div class="state error">${this._esc(detailResult.reason?.message || 'Could not load user detail')}</div>`;
+            return;
+        }
+
+        const d = detailResult.value;
+        const summary = summaryResult.status === 'fulfilled' ? summaryResult.value : null;
+        const { from, to } = this._currentDateRange();
+        const hitsSeries = this._buildDailySeries(summary?.hits, from, to);
+
+        body.innerHTML = `
+            <div class="charts">
+                ${this._chartCard('Page views', d.hits, hitsSeries, 'var(--primary)')}
+            </div>
+            <div class="grid">
+                <div class="card wide">
+                    <h3>Top pages</h3>
+                    ${this._table(
+                        ['Page', 'Hits'],
+                        (d.top_pages || []).map((p) => [this._pageCellHtml(p.route), p.hits])
+                    )}
+                </div>
+                <div class="card wide">
+                    <h3>Recent views (${this._esc(String(d.hits))} hits)</h3>
+                    ${this._table(
+                        ['Page', 'Browser', 'Platform', 'Date'],
+                        (d.views || []).map((v) => [
+                            this._pageCellHtml(v.route),
+                            this._esc(v.browser || 'unknown'),
+                            this._esc(v.platform || 'unknown'),
+                            `${this._esc(v.day || '')} ${this._esc(v.time || '')}`,
+                        ])
+                    )}
+                </div>
+            </div>
+        `;
+        this._bindNavLinks(body);
     }
 
     _render() {
@@ -274,9 +401,10 @@ class PageStatsPage extends HTMLElement {
     }
 
     /**
-     * Empty skeleton for Page Detail / User Detail. Deliberately just a
-     * back-link + title for now (this pass is about establishing routing/
-     * linking, not the detail content) - see class doc comment.
+     * Shell for Page Detail / User Detail: back-link + title, the same
+     * range/refresh toolbar as the dashboard (state is shared via #range,
+     * so the range picked on the dashboard carries over when you drill in),
+     * and a .detail-body container filled by _loadPageDetail()/_loadUserDetail().
      */
     _renderDetailShell() {
         this.shadowRoot.innerHTML = `
@@ -286,12 +414,32 @@ class PageStatsPage extends HTMLElement {
                     <a href="${this._esc(location.pathname)}" class="back-link" data-nav="dashboard">&larr; Back to dashboard</a>
                     <h2>${this._esc(this._detailTitle())}</h2>
                 </div>
-                <div class="card">
-                    <div class="state">This view is coming in a future session - for now it only wires up the URL, back-button and links from the overview.</div>
+                <div class="toolbar">
+                    <div class="range">
+                        <button data-range="7">7d</button>
+                        <button data-range="30">30d</button>
+                        <button data-range="90">90d</button>
+                        <button data-range="all">All time</button>
+                    </div>
+                    <div class="toolbar-end">
+                        <button class="refresh" title="Refresh">&#8635; Refresh</button>
+                    </div>
                 </div>
+                <div class="detail-body"></div>
             </div>
         `;
-        this._bindNavLinks(this.shadowRoot);
+
+        const root = this.shadowRoot;
+        root.querySelectorAll('.range button').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                this.#range = btn.dataset.range;
+                this._highlightRange();
+                this._load();
+            });
+        });
+        root.querySelector('.refresh').addEventListener('click', () => this._load());
+        this._bindNavLinks(root);
+        this._highlightRange();
     }
 
     _detailTitle() {

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -500,7 +500,7 @@ class PageStatsPage extends HTMLElement {
                 ${this._table(
                     ['User', 'Date', 'Browser'],
                     (data.views || []).map((v) => [
-                        this._esc(v.user || '(anonymous)'),
+                        this._esc(v.user || v.ip || '(anonymous)'),
                         `${this._esc(v.day || '')} ${this._esc(v.time || '')}`,
                         this._esc(v.browser || ''),
                     ])

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -111,7 +111,10 @@ class PageStatsPage extends HTMLElement {
                         <button data-range="90">90d</button>
                         <button data-range="all">All time</button>
                     </div>
-                    <button class="refresh" title="Refresh">&#8635; Refresh</button>
+                    <div class="toolbar-end">
+                        <span class="db-size" title="SQLite database file size"></span>
+                        <button class="refresh" title="Refresh">&#8635; Refresh</button>
+                    </div>
                 </div>
                 <div class="body"></div>
 
@@ -178,6 +181,9 @@ class PageStatsPage extends HTMLElement {
         }
 
         const o = this.#overview;
+        const dbBadge = this.shadowRoot.querySelector('.db-size');
+        if (dbBadge) dbBadge.textContent = o.db?.mb !== undefined ? `${o.db.mb} MB` : '';
+
         const { from, to } = this._currentDateRange();
         const hitsSeries = this._buildDailySeries(this.#summary?.hits, from, to);
         const visitorsSeries = this._buildDailySeries(this.#summary?.visitors, from, to);
@@ -188,10 +194,6 @@ class PageStatsPage extends HTMLElement {
                 ${this._chartCard('Page views', o.total_page_views, hitsSeries, 'var(--primary)')}
                 ${this._chartCard('Unique visitors', o.total_unique_visitors, visitorsSeries, '#22d3ee')}
                 ${this._chartCard('Unique users', o.total_unique_users, usersSeries, '#f59e0b')}
-            </div>
-
-            <div class="kpis">
-                ${this._kpi('Database size', `${o.db?.mb ?? 0} MB`)}
             </div>
 
             <div class="grid">
@@ -243,14 +245,6 @@ class PageStatsPage extends HTMLElement {
                 </div>
             </div>
         `;
-    }
-
-    _kpi(label, value) {
-        return `
-            <div class="kpi">
-                <div class="kpi-value">${this._esc(String(value ?? '0'))}</div>
-                <div class="kpi-label">${this._esc(label)}</div>
-            </div>`;
     }
 
     _chartCard(title, total, series, color) {
@@ -505,10 +499,8 @@ class PageStatsPage extends HTMLElement {
                 font-size: 13px;
             }
             .range button.active { background: var(--primary); color: var(--primary-foreground, #fff); border-color: var(--primary); }
-            .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
-            .kpi { border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; display: flex; flex-direction: column; align-items: center; }
-            .kpi-value { font-size: 22px; font-weight: 700; }
-            .kpi-label { font-size: 12px; color: var(--muted-foreground); margin-top: 4px; }
+            .toolbar-end { display: flex; align-items: center; gap: 10px; }
+            .db-size { font-size: 12px; color: var(--muted-foreground); white-space: nowrap; }
             .charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 12px; }
             .chart-card { display: flex; flex-direction: column; }
             .chart-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -885,7 +885,7 @@ class PageStatsPage extends HTMLElement {
         return `
             :host { display: block; color: var(--foreground); font-family: inherit; padding-top: 16px; }
             .wrap { display: flex; flex-direction: column; gap: 16px; }
-            .body { display: flex; flex-direction: column; gap: 16px; }
+            .body, .detail-body { display: flex; flex-direction: column; gap: 16px; }
             .toolbar { display: flex; justify-content: space-between; align-items: center; }
             .range { display: flex; gap: 4px; }
             .range button, .refresh, .lookup-row button, .load-more-recent {

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -412,8 +412,8 @@ class PageStatsPage extends HTMLElement {
     _pageCellHtml(route) {
         const encoded = encodeURIComponent(route || '');
         return `<span class="recent-page-cell">
-            <a href="?view=page-detail&route=${encoded}" class="recent-page-link nav-link" data-nav="page-detail" data-nav-route="${this._esc(route)}" title="View page detail">${this._trendIcon()}</a>
             <a href="${this._esc(route)}" target="_blank" rel="noopener noreferrer" class="recent-page-link" title="${this._esc(route)} in neuem Tab öffnen">${this._externalLinkIcon()}</a>
+            <a href="?view=page-detail&route=${encoded}" class="recent-page-link nav-link" data-nav="page-detail" data-nav-route="${this._esc(route)}" title="View page detail">${this._trendIcon()}</a>
             <span class="recent-page-route" title="${this._esc(route)}">${this._esc(route)}</span>
         </span>`;
     }

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -356,10 +356,17 @@ class PageStatsPage extends HTMLElement {
                 seenX.add(p.x);
                 return true;
             })
-            .map(
-                (p) =>
-                    `<text class="axis-label x-label" x="${p.x.toFixed(1)}" y="${height - 4}" text-anchor="middle">${this._esc(this._formatDayLabel(p.date))}</text>`
-            )
+            .map((p) => {
+                // Middle labels can grow symmetrically; the first/last one
+                // would grow past the viewBox edge with text-anchor="middle"
+                // and get clipped (seen with the rightmost date, e.g.
+                // "24.07." showing as "24.0"), so they anchor toward the
+                // inside instead.
+                const isFirst = p === points[0];
+                const isLast = p === points[points.length - 1];
+                const anchor = isLast ? 'end' : isFirst ? 'start' : 'middle';
+                return `<text class="axis-label x-label" x="${p.x.toFixed(1)}" y="${height - 4}" text-anchor="${anchor}">${this._esc(this._formatDayLabel(p.date))}</text>`;
+            })
             .join('');
 
         const dots = points

--- a/admin-next/pages/page-stats.js
+++ b/admin-next/pages/page-stats.js
@@ -697,11 +697,12 @@ class PageStatsPage extends HTMLElement {
                 ${this._table(
                     ['User', 'Date', 'Browser'],
                     (data.views || []).map((v) => [
-                        this._esc(v.user || v.ip || '(anonymous)'),
+                        this._userCellHtml({ user: v.user, ip: v.ip }),
                         `${this._esc(v.day || '')} ${this._esc(v.time || '')}`,
                         this._esc(v.browser || ''),
                     ])
                 )}`;
+            this._bindNavLinks(resultEl);
         } catch (err) {
             resultEl.innerHTML = `<div class="state error">${this._esc(err.message)}</div>`;
         }
@@ -718,8 +719,9 @@ class PageStatsPage extends HTMLElement {
                 <p>${data.hits} hits</p>
                 ${this._table(
                     ['Route', 'Date'],
-                    (data.views || []).map((v) => [this._esc(v.route || ''), `${this._esc(v.day || '')} ${this._esc(v.time || '')}`])
+                    (data.views || []).map((v) => [this._pageCellHtml(v.route), `${this._esc(v.day || '')} ${this._esc(v.time || '')}`])
                 )}`;
+            this._bindNavLinks(resultEl);
         } catch (err) {
             resultEl.innerHTML = `<div class="state error">${this._esc(err.message)}</div>`;
         }

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -201,6 +201,8 @@ form:
                             type: section
                             text: PLUGIN_PAGE_STATS.TAB_CLASSIC_ADMIN_INFO
                             underline: true
+                            wrapper_classes: "rounded-lg border p-4"
+                            fields: {}
                         page_url_format:
                             type: select
                             label: PLUGIN_PAGE_STATS.PAGE_URL.TEXT
@@ -315,4 +317,6 @@ form:
                             type: section
                             text: PLUGIN_PAGE_STATS.TAB_ADMIN2_INFO
                             underline: true
+                            wrapper_classes: "rounded-lg border p-4"
+                            fields: {}
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -62,236 +62,257 @@ x-widget-limit: &widget-limit
 form:
     validation: loose
     fields:
-        enabled:
-            type: toggle
-            label: PLUGIN_ADMIN.PLUGIN_STATUS
-            highlight: 1
-            default: 0
-            options:
-                1: PLUGIN_ADMIN.ENABLED
-                0: PLUGIN_ADMIN.DISABLED
-            validate:
-                type: bool
-        ignore_errors:
-            type: toggle
-            label: PLUGIN_PAGE_STATS.IGNORE_ERRORS_LABEL
-            help: PLUGIN_PAGE_STATS.IGNORE_ERRORS_HELP
-            highlight: 1
-            default: 0
-            options:
-                1: PLUGIN_ADMIN.ENABLED
-                0: PLUGIN_ADMIN.DISABLED
-            validate:
-                type: bool
-        db:
-            type: text
-            label: PLUGIN_PAGE_STATS.STATS_DB_LABEL
-            help: PLUGIN_PAGE_STATS.STATS_DB_HELP
-
-        anonymize_ips:
-            type: toggle
-            label: PLUGIN_PAGE_STATS.ANONYMIZE_IPS_LABEL
-            help: PLUGIN_PAGE_STATS.ANONYMIZE_IPS_HELP
-            highlight: 1
-            default: 0
-            options:
-                1: PLUGIN_ADMIN.ENABLED
-                0: PLUGIN_ADMIN.DISABLED
-            validate:
-                type: bool
-
-
-        section_widgets:
-            type: section
-            title: PLUGIN_PAGE_STATS.SECTION_WIDGETS
-            text: PLUGIN_PAGE_STATS.SECTION_WIDGETS_LABEL
-            underline: true
+        tabs:
+            type: tabs
             fields:
-                fs2:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.UNIQUE_USERS_WIDGET
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
+                tab_general:
+                    type: tab
+                    title: PLUGIN_PAGE_STATS.TAB_GENERAL
                     fields:
-                        show_unique_users_widget: *widget-enabled
-                        cols_unique_users_widget: *widget-size
-                fs3:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.UNIQUE_VISITORS_WIDGET
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_unique_visitors_widget: *widget-enabled
-                        cols_unique_visitors_widget: *widget-size
-                fs4:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.PAGE_VIEWS_WIDGET
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_page_views_widget: *widget-enabled
-                        cols_page_views_widget: *widget-size
-                fs1:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.TOP_USERS_WIDGET
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_top_users_widget: *widget-enabled
-                        cols_top_users_widget: *widget-size
-                        limit_top_users_widget: *widget-limit
-                fs7:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.TOP_BROWSERS
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_top_browsers: *widget-enabled
-                        cols_top_browsers: *widget-size
-                        limit_top_browsers: *widget-limit
-                        style_top_browsers: *widget-style
-                fs8:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.TOP_COUNTRIES
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_top_countries: *widget-enabled
-                        cols_top_countries: *widget-size
-                        limit_top_countries: *widget-limit
-                        style_top_countries: *widget-style
-                fs9:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.TOP_PLATFORMS
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_top_platforms: *widget-enabled
-                        cols_top_platforms: *widget-size
-                        limit_top_platforms: *widget-limit
-                        style_top_platforms: *widget-style
-
-                fs5:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.RECENTLY_VIEWED_PAGES
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_recently_viewed_pages: *widget-enabled
-                        cols_recently_viewed_pages: *widget-size
-                        limit_recently_viewed_pages: *widget-limit
-                fs6:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.TOP_PAGES
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_top_pages: *widget-enabled
-                        cols_top_pages: *widget-size
-                        limit_top_pages_pages: *widget-limit
-                fs10:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.PAGE_DETAILS.RECENT_VIEWS
-                    collapsed: false      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
-                    fields:
-                        show_pagedetails_recent_views: *widget-enabled
-                        cols_pagedetails_recent_views: *widget-size
-                        limit_pagedetails_recent_views: *widget-limit
-
-        section_behaviour:
-            type: section
-            title: PLUGIN_PAGE_STATS.SECTION_BEHAVIOUR
-            text: PLUGIN_PAGE_STATS.SECTION_BEHAVIOUR_LABEL
-            underline: true
-            fields:
-                datetime_offset:
-                    type: text
-                    label: PLUGIN_PAGE_STATS.DATETIME_OFFSET_LABEL
-                    help: PLUGIN_PAGE_STATS.DATETIME_OFFSET_HELP
-                    default: 'localtime'
-                    validate:
-                      pattern: '[+-][[:digit:]]{2,2}:[[:digit:]]{2,2}|localtime'
-                log_admin:
-                    type: toggle
-                    label: PLUGIN_PAGE_STATS.LOG_ADMIN_LABEL
-                    help: PLUGIN_PAGE_STATS.LOG_ADMIN_HELP
-                    highlight: 0
-                    default: 0
-                    options:
-                        1: PLUGIN_ADMIN.ENABLED
-                        0: PLUGIN_ADMIN.DISABLED
-                    validate:
-                        type: bool
-                log_time_on_page:
-                    type: toggle
-                    label: PLUGIN_PAGE_STATS.LOG_TIME_ON_PAGE_LABEL
-                    help: PLUGIN_PAGE_STATS.LOG_TIME_ON_PAGE_HELP
-                    highlight: 1
-                    default: 1
-                    options:
-                        1: PLUGIN_ADMIN.ENABLED
-                        0: PLUGIN_ADMIN.DISABLED
-                    validate:
-                        type: bool
-                collector_ping_interval:
-                    type: number
-                    label: PLUGIN_PAGE_STATS.COLLECTOR_PING_INTERVAL_LABEL
-                    help: PLUGIN_PAGE_STATS.COLLECTOR_PING_INTERVAL_HELP
-                    default: 15
-                    validate:
-                        type: number
-                        min: 1
-                log_bot:
-                    type: toggle
-                    label: PLUGIN_PAGE_STATS.LOG_BOT_LABEL
-                    help: PLUGIN_PAGE_STATS.LOG_BOT_HELP
-                    highlight: 0
-                    default: 0
-                    options:
-                        1: PLUGIN_ADMIN.ENABLED
-                        0: PLUGIN_ADMIN.DISABLED
-                    validate:
-                        type: bool
-                page_url_format:
-                    type: select
-                    label: PLUGIN_PAGE_STATS.PAGE_URL.TEXT
-                    help: PLUGIN_PAGE_STATS.PAGE_URL.HELP
-                    options:
-                        'url': 'Url'
-                        'title': 'Title'
-                ignored_ips:
-                    type: list
-                    label: PLUGIN_PAGE_STATS.IGNORED_IPS_LABEL
-                    help: PLUGIN_PAGE_STATS.IGNORED_IPS_HELP
-                    style: vertical
-                    fields:
-                        .ip:
+                        enabled:
+                            type: toggle
+                            label: PLUGIN_ADMIN.PLUGIN_STATUS
+                            highlight: 1
+                            default: 0
+                            options:
+                                1: PLUGIN_ADMIN.ENABLED
+                                0: PLUGIN_ADMIN.DISABLED
+                            validate:
+                                type: bool
+                        ignore_errors:
+                            type: toggle
+                            label: PLUGIN_PAGE_STATS.IGNORE_ERRORS_LABEL
+                            help: PLUGIN_PAGE_STATS.IGNORE_ERRORS_HELP
+                            highlight: 1
+                            default: 0
+                            options:
+                                1: PLUGIN_ADMIN.ENABLED
+                                0: PLUGIN_ADMIN.DISABLED
+                            validate:
+                                type: bool
+                        db:
                             type: text
-                            label: PLUGIN_PAGE_STATS.IP
-                            help: PLUGIN_PAGE_STATS.IGNORED_IPS_HELP
-                ignored_urls:
-                    type: list
-                    label: PLUGIN_PAGE_STATS.IGNORED_URLS.LABEL
-                    help: PLUGIN_PAGE_STATS.IGNORED_URLS.HELP
-                    style: vertical
+                            label: PLUGIN_PAGE_STATS.STATS_DB_LABEL
+                            help: PLUGIN_PAGE_STATS.STATS_DB_HELP
+
+                        anonymize_ips:
+                            type: toggle
+                            label: PLUGIN_PAGE_STATS.ANONYMIZE_IPS_LABEL
+                            help: PLUGIN_PAGE_STATS.ANONYMIZE_IPS_HELP
+                            highlight: 1
+                            default: 0
+                            options:
+                                1: PLUGIN_ADMIN.ENABLED
+                                0: PLUGIN_ADMIN.DISABLED
+                            validate:
+                                type: bool
+
+                        section_behaviour:
+                            type: section
+                            title: PLUGIN_PAGE_STATS.SECTION_BEHAVIOUR
+                            text: PLUGIN_PAGE_STATS.SECTION_BEHAVIOUR_LABEL
+                            underline: true
+                            fields:
+                                datetime_offset:
+                                    type: text
+                                    label: PLUGIN_PAGE_STATS.DATETIME_OFFSET_LABEL
+                                    help: PLUGIN_PAGE_STATS.DATETIME_OFFSET_HELP
+                                    default: 'localtime'
+                                    validate:
+                                      pattern: '[+-][[:digit:]]{2,2}:[[:digit:]]{2,2}|localtime'
+                                log_admin:
+                                    type: toggle
+                                    label: PLUGIN_PAGE_STATS.LOG_ADMIN_LABEL
+                                    help: PLUGIN_PAGE_STATS.LOG_ADMIN_HELP
+                                    highlight: 0
+                                    default: 0
+                                    options:
+                                        1: PLUGIN_ADMIN.ENABLED
+                                        0: PLUGIN_ADMIN.DISABLED
+                                    validate:
+                                        type: bool
+                                log_time_on_page:
+                                    type: toggle
+                                    label: PLUGIN_PAGE_STATS.LOG_TIME_ON_PAGE_LABEL
+                                    help: PLUGIN_PAGE_STATS.LOG_TIME_ON_PAGE_HELP
+                                    highlight: 1
+                                    default: 1
+                                    options:
+                                        1: PLUGIN_ADMIN.ENABLED
+                                        0: PLUGIN_ADMIN.DISABLED
+                                    validate:
+                                        type: bool
+                                collector_ping_interval:
+                                    type: number
+                                    label: PLUGIN_PAGE_STATS.COLLECTOR_PING_INTERVAL_LABEL
+                                    help: PLUGIN_PAGE_STATS.COLLECTOR_PING_INTERVAL_HELP
+                                    default: 15
+                                    validate:
+                                        type: number
+                                        min: 1
+                                log_bot:
+                                    type: toggle
+                                    label: PLUGIN_PAGE_STATS.LOG_BOT_LABEL
+                                    help: PLUGIN_PAGE_STATS.LOG_BOT_HELP
+                                    highlight: 0
+                                    default: 0
+                                    options:
+                                        1: PLUGIN_ADMIN.ENABLED
+                                        0: PLUGIN_ADMIN.DISABLED
+                                    validate:
+                                        type: bool
+                                ignored_ips:
+                                    type: list
+                                    label: PLUGIN_PAGE_STATS.IGNORED_IPS_LABEL
+                                    help: PLUGIN_PAGE_STATS.IGNORED_IPS_HELP
+                                    style: vertical
+                                    fields:
+                                        .ip:
+                                            type: text
+                                            label: PLUGIN_PAGE_STATS.IP
+                                            help: PLUGIN_PAGE_STATS.IGNORED_IPS_HELP
+                                ignored_urls:
+                                    type: list
+                                    label: PLUGIN_PAGE_STATS.IGNORED_URLS.LABEL
+                                    help: PLUGIN_PAGE_STATS.IGNORED_URLS.HELP
+                                    style: vertical
+                                    fields:
+                                        .url:
+                                            type: text
+                                            label: PLUGIN_PAGE_STATS.IGNORED_URLS.TEXT
+                                            help: PLUGIN_PAGE_STATS.IGNORED_URLS.HELP
+                                fs11:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.BOT_REGEXP.TEXT
+                                    collapsed: true      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        bot_regexp:
+                                            type: array
+                                            value_only: true
+                                            label: PLUGIN_PAGE_STATS.BOT_REGEXP.TEXT
+                                            help: PLUGIN_PAGE_STATS.BOT_REGEXP.HELP
+
+                tab_classic_admin:
+                    type: tab
+                    title: PLUGIN_PAGE_STATS.TAB_CLASSIC_ADMIN
                     fields:
-                        .url:
-                            type: text
-                            label: PLUGIN_PAGE_STATS.IGNORED_URLS.TEXT
-                            help: PLUGIN_PAGE_STATS.IGNORED_URLS.HELP
-                fs11:
-                    type: fieldset
-                    title: PLUGIN_PAGE_STATS.BOT_REGEXP.TEXT
-                    collapsed: true      # Initial state of fieldset (see collapsible option)
-                    collapsible: true    # Whether one can expand the fieldset or not
+                        classic_admin_info:
+                            type: section
+                            text: PLUGIN_PAGE_STATS.TAB_CLASSIC_ADMIN_INFO
+                            underline: true
+                        page_url_format:
+                            type: select
+                            label: PLUGIN_PAGE_STATS.PAGE_URL.TEXT
+                            help: PLUGIN_PAGE_STATS.PAGE_URL.HELP
+                            options:
+                                'url': 'Url'
+                                'title': 'Title'
+
+                        section_widgets:
+                            type: section
+                            title: PLUGIN_PAGE_STATS.SECTION_WIDGETS
+                            text: PLUGIN_PAGE_STATS.SECTION_WIDGETS_LABEL
+                            underline: true
+                            fields:
+                                fs2:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.UNIQUE_USERS_WIDGET
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_unique_users_widget: *widget-enabled
+                                        cols_unique_users_widget: *widget-size
+                                fs3:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.UNIQUE_VISITORS_WIDGET
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_unique_visitors_widget: *widget-enabled
+                                        cols_unique_visitors_widget: *widget-size
+                                fs4:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.PAGE_VIEWS_WIDGET
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_page_views_widget: *widget-enabled
+                                        cols_page_views_widget: *widget-size
+                                fs1:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.TOP_USERS_WIDGET
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_top_users_widget: *widget-enabled
+                                        cols_top_users_widget: *widget-size
+                                        limit_top_users_widget: *widget-limit
+                                fs7:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.TOP_BROWSERS
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_top_browsers: *widget-enabled
+                                        cols_top_browsers: *widget-size
+                                        limit_top_browsers: *widget-limit
+                                        style_top_browsers: *widget-style
+                                fs8:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.TOP_COUNTRIES
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_top_countries: *widget-enabled
+                                        cols_top_countries: *widget-size
+                                        limit_top_countries: *widget-limit
+                                        style_top_countries: *widget-style
+                                fs9:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.TOP_PLATFORMS
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_top_platforms: *widget-enabled
+                                        cols_top_platforms: *widget-size
+                                        limit_top_platforms: *widget-limit
+                                        style_top_platforms: *widget-style
+
+                                fs5:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.RECENTLY_VIEWED_PAGES
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_recently_viewed_pages: *widget-enabled
+                                        cols_recently_viewed_pages: *widget-size
+                                        limit_recently_viewed_pages: *widget-limit
+                                fs6:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.TOP_PAGES
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_top_pages: *widget-enabled
+                                        cols_top_pages: *widget-size
+                                        limit_top_pages_pages: *widget-limit
+                                fs10:
+                                    type: fieldset
+                                    title: PLUGIN_PAGE_STATS.PAGE_DETAILS.RECENT_VIEWS
+                                    collapsed: false      # Initial state of fieldset (see collapsible option)
+                                    collapsible: true    # Whether one can expand the fieldset or not
+                                    fields:
+                                        show_pagedetails_recent_views: *widget-enabled
+                                        cols_pagedetails_recent_views: *widget-size
+                                        limit_pagedetails_recent_views: *widget-limit
+
+                tab_admin2:
+                    type: tab
+                    title: PLUGIN_PAGE_STATS.TAB_ADMIN2
                     fields:
-                        bot_regexp:
-                            type: array
-                            value_only: true
-                            label: PLUGIN_PAGE_STATS.BOT_REGEXP.TEXT
-                            help: PLUGIN_PAGE_STATS.BOT_REGEXP.HELP
-
-
-
+                        admin2_info:
+                            type: section
+                            text: PLUGIN_PAGE_STATS.TAB_ADMIN2_INFO
+                            underline: true
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -198,10 +198,12 @@ form:
                     title: PLUGIN_PAGE_STATS.TAB_CLASSIC_ADMIN
                     fields:
                         classic_admin_info:
-                            type: display
+                            type: section
+                            title: PLUGIN_PAGE_STATS.TAB_INFO_TITLE
                             text: PLUGIN_PAGE_STATS.TAB_CLASSIC_ADMIN_INFO
                             underline: true
                             wrapper_classes: "rounded-lg border p-4"
+                            fields: {}
                         page_url_format:
                             type: select
                             label: PLUGIN_PAGE_STATS.PAGE_URL.TEXT
@@ -313,8 +315,10 @@ form:
                     title: PLUGIN_PAGE_STATS.TAB_ADMIN2
                     fields:
                         admin2_info:
-                            type: display
+                            type: section
+                            title: PLUGIN_PAGE_STATS.TAB_INFO_TITLE
                             text: PLUGIN_PAGE_STATS.TAB_ADMIN2_INFO
                             underline: true
                             wrapper_classes: "rounded-lg border p-4"
+                            fields: {}
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -234,6 +234,14 @@ form:
                         0: PLUGIN_ADMIN.DISABLED
                     validate:
                         type: bool
+                collector_ping_interval:
+                    type: number
+                    label: PLUGIN_PAGE_STATS.COLLECTOR_PING_INTERVAL_LABEL
+                    help: PLUGIN_PAGE_STATS.COLLECTOR_PING_INTERVAL_HELP
+                    default: 15
+                    validate:
+                        type: number
+                        min: 1
                 log_bot:
                     type: toggle
                     label: PLUGIN_PAGE_STATS.LOG_BOT_LABEL

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -198,11 +198,10 @@ form:
                     title: PLUGIN_PAGE_STATS.TAB_CLASSIC_ADMIN
                     fields:
                         classic_admin_info:
-                            type: section
+                            type: display
                             text: PLUGIN_PAGE_STATS.TAB_CLASSIC_ADMIN_INFO
                             underline: true
                             wrapper_classes: "rounded-lg border p-4"
-                            fields: {}
                         page_url_format:
                             type: select
                             label: PLUGIN_PAGE_STATS.PAGE_URL.TEXT
@@ -314,9 +313,8 @@ form:
                     title: PLUGIN_PAGE_STATS.TAB_ADMIN2
                     fields:
                         admin2_info:
-                            type: section
+                            type: display
                             text: PLUGIN_PAGE_STATS.TAB_ADMIN2_INFO
                             underline: true
                             wrapper_classes: "rounded-lg border p-4"
-                            fields: {}
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Page Stats
 slug: page-stats
 type: plugin
-version: 2.8.0
+version: 2.9.0
 description: Enhaced Analytics for grav
 icon: plug
 author:

--- a/classes/Api/PageStatsApiController.php
+++ b/classes/Api/PageStatsApiController.php
@@ -189,6 +189,13 @@ class PageStatsApiController extends AbstractApiController
 
     /**
      * GET /page-stats/recent
+     *
+     * Powers the dashboard's "Recently viewed pages" card. Returns a flat,
+     * newest-first list ('pages') used for the initial render and for the
+     * "Load more" button (which simply re-requests this endpoint with a
+     * larger `limit`), alongside the same data grouped by day ('by_day',
+     * unchanged) for any future admin page wanting a day-by-day breakdown
+     * akin to the classic-admin "Recently viewed pages" sub-page.
      */
     public function recent(ServerRequestInterface $request): ResponseInterface
     {
@@ -196,9 +203,11 @@ class PageStatsApiController extends AbstractApiController
 
         [$dateFrom, $dateTo] = $this->getDateRange($request);
         $limit = $this->getLimit($request, 50);
+        $stats = $this->getStats();
 
         return ApiResponse::create([
-            'by_day' => $this->getStats()->recentPagesByDay($limit, $dateFrom, $dateTo),
+            'pages' => $stats->recentPages($limit, $dateFrom, $dateTo),
+            'by_day' => $stats->recentPagesByDay($limit, $dateFrom, $dateTo),
         ]);
     }
 

--- a/classes/Api/PageStatsApiController.php
+++ b/classes/Api/PageStatsApiController.php
@@ -90,13 +90,18 @@ class PageStatsApiController extends AbstractApiController
 
         [$dateFrom, $dateTo] = $this->getDateRange($request);
         $limit = $this->getLimit($request, 100);
+        $stats = $this->getStats();
+        $filter = ['route' => $route];
 
-        $views = $this->getStats()->recentPages($limit, $dateFrom, $dateTo, ['route' => $route]);
+        $views = $stats->recentPages($limit, $dateFrom, $dateTo, $filter);
 
         return ApiResponse::create([
             'route' => $route,
             'hits' => count($views),
             'visitors' => count(array_unique(array_column($views, 'ip'))),
+            'top_countries' => $stats->topCountries(5, $dateFrom, $dateTo, $filter),
+            'top_browsers' => $stats->topBrowsers(5, $dateFrom, $dateTo, $filter),
+            'top_platforms' => $stats->topPlatforms(5, $dateFrom, $dateTo, $filter),
             'views' => $views,
         ]);
     }
@@ -186,14 +191,16 @@ class PageStatsApiController extends AbstractApiController
 
         [$dateFrom, $dateTo] = $this->getDateRange($request);
         $limit = $this->getLimit($request, 100);
+        $stats = $this->getStats();
 
         $filter = $user ? ['user' => $user] : ['ip' => $ip];
-        $views = $this->getStats()->recentPages($limit, $dateFrom, $dateTo, $filter);
+        $views = $stats->recentPages($limit, $dateFrom, $dateTo, $filter);
 
         return ApiResponse::create([
             'user' => $user,
             'ip' => $ip,
             'hits' => count($views),
+            'top_pages' => $stats->pagesSummary(5, $dateFrom, $dateTo, $filter),
             'views' => $views,
         ]);
     }
@@ -223,18 +230,48 @@ class PageStatsApiController extends AbstractApiController
     }
 
     /**
-     * GET /page-stats/summary
+     * GET /page-stats/summary  (dashboard)
+     *  or  /page-stats/summary?route=...  /  ?user=...  /  ?ip=...  (detail views)
      *
      * Time series data (hits/visitors/users per day) used to draw the trend
-     * chart on the dashboard.
+     * chart on the dashboard, and - filtered by one of route/user/ip - the
+     * equivalent per-entity trend chart on the Page/User Detail views.
      */
     public function summary(ServerRequestInterface $request): ResponseInterface
     {
         $this->requirePermission($request, self::READ_PERMISSION);
 
         [$dateFrom, $dateTo] = $this->getDateRange($request);
+        $filter = $this->getEntityFilter($request);
 
-        return ApiResponse::create($this->getStats()->siteSummary($dateFrom, $dateTo));
+        return ApiResponse::create($this->getStats()->siteSummary($dateFrom, $dateTo, $filter));
+    }
+
+    /**
+     * Builds the same style of equality-filter array Stats::query() expects
+     * (['route' => ...] / ['user' => ...] / ['ip' => ...]) from whichever of
+     * those query params is present. Returns [] (no filter) if none are -
+     * that's what keeps the dashboard's own /summary call, which passes
+     * none of them, working exactly as before.
+     */
+    private function getEntityFilter(ServerRequestInterface $request): array
+    {
+        $route = $this->getQueryParam($request, 'route');
+        if ($route) {
+            return ['route' => $route];
+        }
+
+        $user = $this->getQueryParam($request, 'user');
+        if ($user) {
+            return ['user' => $user];
+        }
+
+        $ip = $this->getQueryParam($request, 'ip');
+        if ($ip) {
+            return ['ip' => $ip];
+        }
+
+        return [];
     }
 
     private function getStats(): Stats

--- a/classes/Api/PageStatsApiController.php
+++ b/classes/Api/PageStatsApiController.php
@@ -162,26 +162,37 @@ class PageStatsApiController extends AbstractApiController
     }
 
     /**
-     * GET /page-stats/users/detail?user=someuser
+     * GET /page-stats/users/detail?user=someuser  -or-  ?ip=1.2.3.4
+     *
+     * Accepts either a "user" or an "ip" query parameter. The "ip" variant
+     * exists for anonymous visitors that have no username but are still
+     * individually identifiable by IP (see admin-next/pages/page-stats.js,
+     * "Recently viewed pages" - a row with no user falls back to showing/
+     * linking the IP instead of a flat "(anonymous)", mirroring how the
+     * classic-admin user-details.html.twig template detected an IP-shaped
+     * "user" parameter and filtered by the ip column instead).
      */
     public function userDetail(ServerRequestInterface $request): ResponseInterface
     {
         $this->requirePermission($request, self::READ_PERMISSION);
 
         $user = $this->getQueryParam($request, 'user');
-        if (!$user) {
-            throw new ValidationException('A "user" query parameter is required.', [
-                ['field' => 'user', 'message' => 'This field is required.'],
+        $ip = $this->getQueryParam($request, 'ip');
+        if (!$user && !$ip) {
+            throw new ValidationException('A "user" or "ip" query parameter is required.', [
+                ['field' => 'user', 'message' => 'Either "user" or "ip" is required.'],
             ]);
         }
 
         [$dateFrom, $dateTo] = $this->getDateRange($request);
         $limit = $this->getLimit($request, 100);
 
-        $views = $this->getStats()->recentPages($limit, $dateFrom, $dateTo, ['user' => $user]);
+        $filter = $user ? ['user' => $user] : ['ip' => $ip];
+        $views = $this->getStats()->recentPages($limit, $dateFrom, $dateTo, $filter);
 
         return ApiResponse::create([
             'user' => $user,
+            'ip' => $ip,
             'hits' => count($views),
             'views' => $views,
         ]);

--- a/classes/Stats.php
+++ b/classes/Stats.php
@@ -415,9 +415,9 @@ class Stats
      */
     public function siteSummary(?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
     {
-        $hits = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, count(route) as hits FROM data %where GROUP BY date(datetime(date), :offset)', $params, null, $dateFrom, $dateTo);
-        $visitors = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct ip) as hits FROM data %where GROUP BY date(datetime(date), :offset)',  $params, null, $dateFrom, $dateTo);
-        $users = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct user) as hits FROM data %where GROUP BY date(datetime(date), :offset)',  $params, null, $dateFrom, $dateTo);
+        $hits = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, count(route) as hits FROM data %where GROUP BY date(datetime(date), :offset) ORDER BY date ASC', $params, null, $dateFrom, $dateTo);
+        $visitors = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct ip) as hits FROM data %where GROUP BY date(datetime(date), :offset) ORDER BY date ASC',  $params, null, $dateFrom, $dateTo);
+        $users = $this->query('SELECT date(datetime(date), :offset) as date, route, page_title, ip, count(distinct user) as hits FROM data %where GROUP BY date(datetime(date), :offset) ORDER BY date ASC',  $params, null, $dateFrom, $dateTo);
 
         return [
             'hits' => $hits,

--- a/classes/Stats.php
+++ b/classes/Stats.php
@@ -248,12 +248,17 @@ class Stats
 
     /**
      * gets most viewed pages
+     *
+     * $params is an optional equality-filter array (same convention as
+     * topBrowsers()/topCountries()/recentPages() etc.), e.g. ['user' => ...]
+     * or ['ip' => ...] to get the pages a specific visitor viewed most,
+     * for Admin2's User Detail view.
      */
-    public function pagesSummary(int $limit = 10, ?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null)
+    public function pagesSummary(int $limit = 10, ?DateTimeImmutable $dateFrom = null, ?DateTimeImmutable $dateTo = null, array $params = [])
     {
         $q = 'SELECT route, page_title, count(route) as hits, count(distinct ip) as visitors, count(distinct user) as users FROM data %where GROUP BY page_title ORDER BY hits DESC';
 
-        return $this->query($q, [], $limit, $dateFrom, $dateTo);
+        return $this->query($q, $params, $limit, $dateFrom, $dateTo);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,5 @@
     "require-dev": {
         "marcocesarato/php-conventional-changelog": "^1.15"
     },
-    "version": "2.8.0"
+    "version": "2.9.0"
 }

--- a/docs/FORK-NOTES.md
+++ b/docs/FORK-NOTES.md
@@ -1,0 +1,107 @@
+# Fork-Notizen: Branch-/Tag-Workflow
+
+> Internes Betriebshandbuch für den Fork
+> [chrisschm/grav-plugin-page-stats](https://github.com/chrisschm/grav-plugin-page-stats),
+> solange offen ist, ob [PR #54](https://github.com/francodacosta/grav-plugin-page-stats/pull/54)
+> beim Original-Repo (`francodacosta/grav-plugin-page-stats`) gemerged wird.
+> Keine Beitrags-Richtlinie für Dritte (dafür ggf. später eine echte
+> `CONTRIBUTING.md`) – nur Gedächtnisstütze für uns selbst.
+
+## Warum dieses Dokument existiert
+
+`francodacosta`s eigene Grav-Website befand sich zum Zeitpunkt dieser
+Notiz im Installationsmodus – ein Hinweis darauf, dass eine Reaktion auf
+PR #54 ungewiss ist, zeitlich wie inhaltlich. Bis sich das klärt, arbeiten
+wir trotzdem weiter am Plugin (Admin2-Dashboard-Verbesserungen,
+Bugfixes) und brauchen dafür eine Struktur, die **beide** möglichen
+Ausgänge offenhält, ohne dass wir uns vorher festlegen müssen.
+
+## Branch-Bedeutung
+
+| Branch    | Zweck                                                                    | Synchron mit Original? |
+|-----------|---------------------------------------------------------------------------|-------------------------|
+| `master`  | Stabil: nur Commits, die auch im Original-Repo akzeptiert wurden (Original + akzeptierte PRs). | Ja |
+| `develop` | Alle lokalen Änderungen, die noch nicht im Original sind.                | Nein |
+
+Auf dem Server per `git switch master` / `git switch develop` schnell
+umschaltbar.
+
+## Tag-Schema
+
+Tags markieren einen **verifizierten, stabilen Stand** auf `develop` –
+nicht jeden einzelnen Commit. Namensschema (passend zum bereits
+etablierten Datums-Schema der Chat-Zusammenfassungen):
+
+```
+develop-JJJJ-MM-TT
+```
+
+Setzen, nachdem ein Stand auf dem Server geprüft wurde:
+
+```bash
+git switch develop
+git status                     # muss "clean" sein
+git tag -a develop-2026-07-25 -m "Kurzbeschreibung des Stands"
+git push origin develop-2026-07-25   # Tags werden NICHT automatisch mit "git push" mitgeschickt
+```
+
+Kontrolle:
+
+```bash
+git tag -l
+git ls-remote --tags origin
+```
+
+**Wichtige Regel:** Sobald ein Commit getaggt ist, nicht mehr per
+`reset --hard` oder Rebase über ihn hinweg zurückgehen – sonst zeigt der
+Tag ins Leere. Das schon einmal bewusst durchgeführte `reset --hard
+HEAD~2` auf `master` (Abspaltung von `develop`, siehe Commit-Historie)
+war unkritisch, weil zu dem Zeitpunkt noch kein Tag auf den entfernten
+Commits saß.
+
+## Commit-Message-Konvention
+
+An der bisherigen Historie orientiert: `feat:`, `fix:`, `docs:`,
+`sync:`-Präfixe, ein Anliegen pro Commit, wo sinnvoll trennbar.
+
+## Eigenständige Fixes / möglicher separater PR
+
+Manche Änderungen sind inhaltlich unabhängig vom Admin2-Dashboard aus
+PR #54 (z. B. reine Datenschicht-Bugfixes in `classes/Stats.php`, die
+auch unter klassischem Admin1 relevant wären). Solche Fixes müssen
+**nicht** vorab in einen eigenen Branch ausgelagert werden – dafür reicht
+es, sie als eigenen, in sich geschlossenen Commit auf `develop` zu
+machen. Falls sich später zeigt, dass ein eigenständiger PR dafür Sinn
+ergibt, lässt sich der Commit per `git cherry-pick` nachträglich
+herausziehen:
+
+```bash
+git switch master
+git switch -c fix/<kurzbeschreibung>
+git cherry-pick <commit-hash>
+git push origin fix/<kurzbeschreibung>
+# → PR gegen francodacosta/grav-plugin-page-stats öffnen
+```
+
+**Aktuelle Einschätzung (Stand dieser Notiz):** Angesichts der
+ungewissen Maintainer-Aktivität wird das vorerst nicht aktiv verfolgt –
+weitere PRs gegen das Original-Repo ergeben erst wieder Sinn, wenn sich
+zeigt, dass dort überhaupt reagiert wird.
+
+## Zwei offene Zukunftspfade
+
+- **PR #54 wird gemerged:** `upstream/master` in eigenen `master`
+  mergen, danach `develop` per `git rebase master` (oder bei
+  Konflikten einfacher: `git merge master`) nachziehen.
+- **Keine Reaktion vom Maintainer:** `develop` wird zum neuen `master`
+  eines eigenständigen Forks/Plugins. Erst dann wird ein "echter"
+  Versions-Tag (z. B. `v2.9.0` oder klar unterscheidbar wie
+  `v3.0.0-jcs`) und ein GitHub-Release mit ZIP-Asset sinnvoll – falls
+  eine eigenständige GPM-Veröffentlichung angestrebt wird. Achtung:
+  das automatische GitHub-Source-ZIP hat als Top-Level-Ordner
+  `grav-plugin-page-stats-<version>/`, nicht `page-stats/` – für
+  Fremdnutzer ggf. ein eigenes, korrekt benanntes ZIP als Release-Asset
+  ergänzen.
+
+Beide Pfade bleiben mit der aktuellen `master`/`develop`-Struktur offen;
+es ist keine Vorab-Entscheidung nötig.

--- a/languages.yaml
+++ b/languages.yaml
@@ -4,6 +4,12 @@ en:
     STATS_DB_LABEL: Page Stats DB path
     STATS_DB_HELP: Path to db relative to Grav root
 
+    TAB_GENERAL: General
+    TAB_CLASSIC_ADMIN: "Grav 1.7 / Classic Admin"
+    TAB_ADMIN2: "Grav 2.0 / Admin2"
+    TAB_CLASSIC_ADMIN_INFO: "These settings only affect the classic Admin (Grav 1.x) dashboard widgets and detail pages. They have no effect on the Admin2 (Grav 2.0) dashboard."
+    TAB_ADMIN2_INFO: "The Admin2 dashboard currently has no additional settings of its own - its layout is defined directly in admin-next/pages/page-stats.js. This tab is reserved for future Admin2-specific options."
+
     WIDGET:
         ENABLED:
             TEXT: Enabled
@@ -133,6 +139,12 @@ fr:
     PAGE_STATS: Statistiques
     STATS_DB_LABEL: Chemin de la base de données des statistiques
     STATS_DB_HELP: Chemin vers la base de données, relatif à la racine de Grav
+
+    TAB_GENERAL: Général
+    TAB_CLASSIC_ADMIN: "Grav 1.7 / Admin classique"
+    TAB_ADMIN2: "Grav 2.0 / Admin2"
+    TAB_CLASSIC_ADMIN_INFO: "Ces réglages n'affectent que les widgets et pages de détail du tableau de bord de l'admin classique (Grav 1.x). Ils n'ont aucun effet sur le tableau de bord Admin2 (Grav 2.0)."
+    TAB_ADMIN2_INFO: "Le tableau de bord Admin2 n'a actuellement pas de réglages supplémentaires propres - sa mise en page est définie directement dans admin-next/pages/page-stats.js. Cet onglet est réservé aux futures options spécifiques à Admin2."
 
     WIDGET:
         ENABLED:

--- a/languages.yaml
+++ b/languages.yaml
@@ -9,6 +9,7 @@ en:
     TAB_ADMIN2: "Grav 2.0 / Admin2"
     TAB_CLASSIC_ADMIN_INFO: "These settings only affect the classic Admin (Grav 1.x) dashboard widgets and detail pages. They have no effect on the Admin2 (Grav 2.0) dashboard."
     TAB_ADMIN2_INFO: "The Admin2 dashboard currently has no additional settings of its own - its layout is defined directly in admin-next/pages/page-stats.js. This tab is reserved for future Admin2-specific options."
+    TAB_INFO_TITLE: Information
 
     WIDGET:
         ENABLED:
@@ -145,6 +146,7 @@ fr:
     TAB_ADMIN2: "Grav 2.0 / Admin2"
     TAB_CLASSIC_ADMIN_INFO: "Ces réglages n'affectent que les widgets et pages de détail du tableau de bord de l'admin classique (Grav 1.x). Ils n'ont aucun effet sur le tableau de bord Admin2 (Grav 2.0)."
     TAB_ADMIN2_INFO: "Le tableau de bord Admin2 n'a actuellement pas de réglages supplémentaires propres - sa mise en page est définie directement dans admin-next/pages/page-stats.js. Cet onglet est réservé aux futures options spécifiques à Admin2."
+    TAB_INFO_TITLE: Information
 
     WIDGET:
         ENABLED:

--- a/languages.yaml
+++ b/languages.yaml
@@ -26,6 +26,8 @@ en:
 
     LOG_TIME_ON_PAGE_LABEL: Log time on page
     LOG_TIME_ON_PAGE_HELP: If enabled Front End will trigger a ping event at regular intervals to mark the user as still on the page
+    COLLECTOR_PING_INTERVAL_LABEL: Time on page ping interval (seconds)
+    COLLECTOR_PING_INTERVAL_HELP: How often (in seconds) the Front End sends a ping while "Log time on page" is enabled. Only takes effect if that option is on.
     # STATS_DB_CREATE_LABEL: Recreate Stats database
     # STATS_DB_CREATE_HELP: This will create a db at the path specified and will overrite an existinf one without any questions
     # STATS_DB_CREATE_BTN_TEXT: Create new Stats database
@@ -154,6 +156,8 @@ fr:
 
     LOG_TIME_ON_PAGE_LABEL: Enregistrer le temps passé sur la page
     LOG_TIME_ON_PAGE_HELP: "Si activé, le front-end déclenchera un événement de ping à intervalles réguliers pour indiquer que l'utilisateur est toujours sur la page"
+    COLLECTOR_PING_INTERVAL_LABEL: "Intervalle de ping (temps passé sur la page, en secondes)"
+    COLLECTOR_PING_INTERVAL_HELP: "Fréquence (en secondes) à laquelle le front-end envoie un ping lorsque « Enregistrer le temps passé sur la page » est activé. N'a d'effet que si cette option est active."
     # STATS_DB_CREATE_LABEL: Reconstruire la base de données des statistiques
     # STATS_DB_CREATE_HELP: "Cela créera une base de données à l'emplacement spécifié et écrasera celle existante sans confirmation"
     # STATS_DB_CREATE_BTN_TEXT: Créer une nouvelle base de données des statistiques


### PR DESCRIPTION
Follow-up to #54. Adds the features mentioned in that PR's discussion (originally on the develop branch): Page/User Detail sub-views, config reorganized into General/Classic Admin/Admin2 tabs, trend charts + country flags, load-more pagination with browser/platform columns, and IP fallback for anonymous hits. See CHANGELOG for details.

Sub-view routing works around Admin2's single-dynamic-segment router (no catch-all for plugin pages) via query parameters (?view=page-detail&route=...) on the fixed plugin route, driven by native history.pushState()/popstate — verified against hard reload and browser back/forward.

Rebased onto current master (2.8.0), no conflicts.